### PR TITLE
add temperature-unit configuration for specifying weather in celsius or fahrenheit

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -513,12 +513,17 @@ Each bar represents a 2 hour interval. The yellow background represents sunrise 
 | ---- | ---- | -------- | ------- |
 | location | string | yes |  |
 | hide-location | boolean | no | false |
+| temperature-unit | string | no | celsius |
 
 ##### `location`
 The name of the city and country to fetch weather information for. Attempting to launch the applcation with an invalid location will result in an error. You can use the [gecoding API page](https://open-meteo.com/en/docs/geocoding-api) to search for your specific location. Glance will use the first result from the list if there are multiple.
 
 ##### `hide-location`
 Optionally don't display the location name on the widget.
+
+##### `temperature-unit`
+
+The unit of temperature to display. Possible values are `celsius` and `fahrenheit`.
 
 ### Monitor
 Display a list of sites and whether they are reachable (online) or not. This is determined by sending a HEAD request to the specified URL, if the response is 200 then the site is OK. The time it took to receive a response is also shown in milliseconds.

--- a/internal/assets/templates/weather.html
+++ b/internal/assets/templates/weather.html
@@ -2,7 +2,7 @@
 
 {{ define "widget-content" }}
 <div class="size-h2 color-highlight text-center">{{ .Weather.WeatherCodeAsString }}</div>
-<div class="size-h4 text-center">Feels like {{ .Weather.ApparentTemperature }}°C</div>
+<div class="size-h4 text-center">Feels like {{ .Weather.ApparentTemperature }}{{ .Weather.ApparentTemperatureUnit }}</div>
 
 <div class="weather-columns flex margin-top-15 justify-center">
     {{ range $i, $column := .Weather.Columns }}

--- a/internal/feed/openmeteo.go
+++ b/internal/feed/openmeteo.go
@@ -40,6 +40,9 @@ type WeatherResponseJson struct {
 		ApparentTemperature float64 `json:"apparent_temperature"`
 		WeatherCode         int     `json:"weather_code"`
 	} `json:"current"`
+	CurrentUnits struct {
+		ApparentTemperature string `json:"apparent_temperature"`
+	} `json:"current_units"`
 }
 
 type weatherColumn struct {
@@ -80,7 +83,7 @@ func barIndexFromHour(h int) int {
 
 // TODO: bunch of spaget, refactor
 // TODO: allow changing between C and F
-func FetchWeatherForPlace(place *PlaceJson) (*Weather, error) {
+func FetchWeatherForPlace(place *PlaceJson, temperatureUnit string) (*Weather, error) {
 	query := url.Values{}
 
 	query.Add("latitude", fmt.Sprintf("%f", place.Latitude))
@@ -91,6 +94,7 @@ func FetchWeatherForPlace(place *PlaceJson) (*Weather, error) {
 	query.Add("current", "temperature_2m,apparent_temperature,weather_code,wind_speed_10m")
 	query.Add("hourly", "temperature_2m,precipitation_probability")
 	query.Add("daily", "sunrise,sunset")
+	query.Add("temperature_unit", temperatureUnit)
 
 	requestUrl := "https://api.open-meteo.com/v1/forecast?" + query.Encode()
 	request, _ := http.NewRequest("GET", requestUrl, nil)
@@ -140,12 +144,13 @@ func FetchWeatherForPlace(place *PlaceJson) (*Weather, error) {
 	}
 
 	return &Weather{
-		Temperature:         int(responseJson.Current.Temperature),
-		ApparentTemperature: int(responseJson.Current.ApparentTemperature),
-		WeatherCode:         responseJson.Current.WeatherCode,
-		CurrentColumn:       currentBar,
-		SunriseColumn:       sunriseBar,
-		SunsetColumn:        sunsetBar,
-		Columns:             bars,
+		Temperature:             int(responseJson.Current.Temperature),
+		ApparentTemperature:     int(responseJson.Current.ApparentTemperature),
+		ApparentTemperatureUnit: responseJson.CurrentUnits.ApparentTemperature,
+		WeatherCode:             responseJson.Current.WeatherCode,
+		CurrentColumn:           currentBar,
+		SunriseColumn:           sunriseBar,
+		SunsetColumn:            sunsetBar,
+		Columns:                 bars,
 	}, nil
 }

--- a/internal/feed/primitives.go
+++ b/internal/feed/primitives.go
@@ -29,13 +29,14 @@ type Calendar struct {
 }
 
 type Weather struct {
-	Temperature         int
-	ApparentTemperature int
-	WeatherCode         int
-	CurrentColumn       int
-	SunriseColumn       int
-	SunsetColumn        int
-	Columns             []weatherColumn
+	Temperature             int
+	ApparentTemperature     int
+	ApparentTemperatureUnit string
+	WeatherCode             int
+	CurrentColumn           int
+	SunriseColumn           int
+	SunsetColumn            int
+	Columns                 []weatherColumn
 }
 
 type AppRelease struct {

--- a/internal/widget/weather.go
+++ b/internal/widget/weather.go
@@ -10,12 +10,13 @@ import (
 )
 
 type Weather struct {
-	widgetBase   `yaml:",inline"`
-	Location     string          `yaml:"location"`
-	HideLocation bool            `yaml:"hide-location"`
-	Place        *feed.PlaceJson `yaml:"-"`
-	Weather      *feed.Weather   `yaml:"-"`
-	TimeLabels   [12]string      `yaml:"-"`
+	widgetBase      `yaml:",inline"`
+	Location        string          `yaml:"location"`
+	HideLocation    bool            `yaml:"hide-location"`
+	TemperatureUnit string          `yaml:"temperature-unit"`
+	Place           *feed.PlaceJson `yaml:"-"`
+	Weather         *feed.Weather   `yaml:"-"`
+	TimeLabels      [12]string      `yaml:"-"`
 }
 
 var timeLabels = [12]string{"2am", "4am", "6am", "8am", "10am", "12pm", "2pm", "4pm", "6pm", "8pm", "10pm", "12am"}
@@ -23,6 +24,12 @@ var timeLabels = [12]string{"2am", "4am", "6am", "8am", "10am", "12pm", "2pm", "
 func (widget *Weather) Initialize() error {
 	widget.withTitle("Weather").withCacheOnTheHour()
 	widget.TimeLabels = timeLabels
+	if widget.TemperatureUnit == "" {
+		widget.TemperatureUnit = "celsius"
+	}
+	if widget.TemperatureUnit != "celsius" && widget.TemperatureUnit != "fahrenheit" {
+		return fmt.Errorf("invalid temperature unit: %s", widget.TemperatureUnit)
+	}
 
 	place, err := feed.FetchPlaceFromName(widget.Location)
 
@@ -36,7 +43,7 @@ func (widget *Weather) Initialize() error {
 }
 
 func (widget *Weather) Update(ctx context.Context) {
-	weather, err := feed.FetchWeatherForPlace(widget.Place)
+	weather, err := feed.FetchWeatherForPlace(widget.Place, widget.TemperatureUnit)
 
 	if !widget.canContinueUpdateAfterHandlingErr(err) {
 		return


### PR DESCRIPTION
* adds `temperature-unit` to weather config
* use temperature units from open-meteo.com in the weather HTML template
* updates configuration docs