### PR TITLE
Reduce the docker image size further by basing on scratch instead of alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM alpine:3.19
+FROM alpine:3.19 as base
+RUN apk --no-cache add ca-certificates
 
+FROM scratch
 ARG TARGETOS
 ARG TARGETARCH
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 WORKDIR /app
 COPY build/glance-$TARGETOS-$TARGETARCH /app/glance


### PR DESCRIPTION
Unfortunately /etc/ssl/certs/ca-certificates.crt is still a dependency, but it's easy enough to just grab it from an Alpine image during build

This shaves off about an additional ~25% (~5mb) of uncompressed image size.