### PR TITLE
feat: add group title to video bundles

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -434,6 +434,7 @@ Preview:
 | ---- | ---- | -------- | ------- |
 | channels | array | yes | |
 | limit | integer | no | 25 |
+| group-title | string | no | VIDEOS |
 | video-url-template | string | no | https://www.youtube.com/watch?v={VIDEO-ID} |
 
 ##### `channels`
@@ -458,6 +459,13 @@ video-url-template: https://invidious.your-domain.com/watch?v={VIDEO-ID}
 Placeholders:
 
 `{VIDEO-ID}` - the ID of the video
+
+##### `group-title`
+Add a separate title for the group of videos in the widget, defaults to "VIDEOS". Useful when you have to group videos by categories. Example:
+
+```yaml
+group-title: "Reviews"
+```
 
 ### Hacker News
 Display a list of posts from [Hacker News](https://news.ycombinator.com/).

--- a/internal/widget/videos.go
+++ b/internal/widget/videos.go
@@ -12,13 +12,18 @@ import (
 type Videos struct {
 	widgetBase       `yaml:",inline"`
 	Videos           feed.Videos `yaml:"-"`
+	GroupTitle       string      `yaml:"group-title"`
 	VideoUrlTemplate string      `yaml:"video-url-template"`
 	Channels         []string    `yaml:"channels"`
 	Limit            int         `yaml:"limit"`
 }
 
 func (widget *Videos) Initialize() error {
-	widget.withTitle("Videos").withCacheDuration(time.Hour)
+	
+	if widget.GroupTitle == "" {
+		widget.GroupTitle = "VIDEOS"
+	}
+	widget.withTitle(widget.GroupTitle).withCacheDuration(time.Hour)
 
 	if widget.Limit <= 0 {
 		widget.Limit = 25


### PR DESCRIPTION
Add an optional group title to group of Youtube videos, if you want to separate them out.

Example:

```
  - name: YouTube
    columns:
      - size: full
        widgets:
          - type: videos
            group-title: "Reviews"
            channels:
              - UCBJycsmduvYEL83R_U4JriQ # MKBHD
              - UCVYamHliCI9rw1tHR1xbkfw # Dave2D
          - type: videos
            channels:
              - UCO-uVs959_GUzzUx4ctwMMQ # MotorInc
              - UCjWs7BxyjO5SLqevxSmp4vQ # Autocar India
```

![Screenshot 2024-05-05 at 21 35 34](https://github.com/glanceapp/glance/assets/8710439/8acf9906-8b32-447b-a84a-03b65fb15ab7)
