### PR TITLE
Add 24-hour time format support for weather

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -683,7 +683,7 @@ The name of the city and country to fetch weather information for. Attempting to
 Whether to show the temperature in celsius or fahrenheit, possible values are `metric` or `imperial`.
 
 #### `hour-format`
-Whether to show the hours of the day in 12-hour format or 24-hour format
+Whether to show the hours of the day in 12-hour format or 24-hour format. Possible values are `12h` and `24h`.
 
 ##### `hide-location`
 Optionally don't display the location name on the widget.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -647,6 +647,7 @@ Example:
 ```yaml
 - type: weather
   units: metric
+  hour-format: 12h
   location: London, United Kingdom
 ```
 
@@ -671,6 +672,7 @@ Each bar represents a 2 hour interval. The yellow background represents sunrise 
 | ---- | ---- | -------- | ------- |
 | location | string | yes |  |
 | units | string | no | metric |
+| hour-format | string | no | 12h |
 | hide-location | boolean | no | false |
 | show-area-name | boolean | no | false |
 
@@ -679,6 +681,9 @@ The name of the city and country to fetch weather information for. Attempting to
 
 ##### `units`
 Whether to show the temperature in celsius or fahrenheit, possible values are `metric` or `imperial`.
+
+#### `hour-format`
+Whether to show the hours of the day in 12-hour format or 24-hour format
 
 ##### `hide-location`
 Optionally don't display the location name on the widget.

--- a/internal/widget/weather.go
+++ b/internal/widget/weather.go
@@ -14,17 +14,26 @@ type Weather struct {
 	Location     string          `yaml:"location"`
 	ShowAreaName bool            `yaml:"show-area-name"`
 	HideLocation bool            `yaml:"hide-location"`
+	HourFormat   string          `yaml:"hour-format"`
 	Units        string          `yaml:"units"`
 	Place        *feed.PlaceJson `yaml:"-"`
 	Weather      *feed.Weather   `yaml:"-"`
 	TimeLabels   [12]string      `yaml:"-"`
 }
 
-var timeLabels = [12]string{"2am", "4am", "6am", "8am", "10am", "12pm", "2pm", "4pm", "6pm", "8pm", "10pm", "12am"}
+var timeLabels12h = [12]string{"2am", "4am", "6am", "8am", "10am", "12pm", "2pm", "4pm", "6pm", "8pm", "10pm", "12am"}
+var timeLabels24h = [12]string{"02:00", "04:00", "06:00", "08:00", "10:00", "12:00", "14:00", "16:00", "18:00", "20:00", "22:00", "24:00"}
 
 func (widget *Weather) Initialize() error {
 	widget.withTitle("Weather").withCacheOnTheHour()
-	widget.TimeLabels = timeLabels
+
+	if widget.HourFormat == "" || widget.HourFormat == "12h" {
+		widget.TimeLabels = timeLabels12h
+	} else if widget.HourFormat == "24h" {
+		widget.TimeLabels = timeLabels24h
+	} else if widget.Units != "12h" && widget.Units != "24h" {
+		return fmt.Errorf("invalid hour format '%s' for weather, must be either 12h or 24h", widget.HourFormat)
+	}
 
 	if widget.Units == "" {
 		widget.Units = "metric"

--- a/internal/widget/weather.go
+++ b/internal/widget/weather.go
@@ -31,8 +31,8 @@ func (widget *Weather) Initialize() error {
 		widget.TimeLabels = timeLabels12h
 	} else if widget.HourFormat == "24h" {
 		widget.TimeLabels = timeLabels24h
-	} else if widget.Units != "12h" && widget.Units != "24h" {
-		return fmt.Errorf("invalid hour format '%s' for weather, must be either 12h or 24h", widget.HourFormat)
+	} else {
+		return fmt.Errorf("invalid hour format '%s' for weather widget, must be either 12h or 24h", widget.HourFormat)
 	}
 
 	if widget.Units == "" {


### PR DESCRIPTION
Added `hour-format` option to the configuration so that the forecast could be in 12-hour or 24-hour format, with 12-hour being the default.

![image](https://github.com/glanceapp/glance/assets/44239968/ef6fa83c-2d6b-4789-a082-80100e0f5f56)