### PR TITLE
Adds reporting serve errors

### DIFF
--- a/internal/glance/main.go
+++ b/internal/glance/main.go
@@ -36,7 +36,7 @@ func Main() int {
 			return 1
 		}
 
-		if app.Serve() != nil {
+		if err := app.Serve(); err != nil {
 			fmt.Printf("http server error: %v\n", err)
 			return 1
 		}


### PR DESCRIPTION
Tried building and running locally and got a nondescript error message:

```
2024/05/17 10:01:21 INFO Starting server host="" port=8080                                      
http server error: <nil>
```

Peeked under the hood and changed it to also report the `err` that can be returned by `app.Serve()` and then got the following:

```
2024/05/17 10:03:44 INFO Starting server host="" port=8080                                      
http server error: listen tcp :8080: bind: address already in use 
```

Much more helpful!