### PR TITLE
Specify the correct method in the Monitor widget documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -697,7 +697,7 @@ Greenville, United States
 ```
 
 ### Monitor
-Display a list of sites and whether they are reachable (online) or not. This is determined by sending a HEAD request to the specified URL, if the response is 200 then the site is OK. The time it took to receive a response is also shown in milliseconds.
+Display a list of sites and whether they are reachable (online) or not. This is determined by sending a GET request to the specified URL, if the response is 200 then the site is OK. The time it took to receive a response is also shown in milliseconds.
 
 Example:
 


### PR DESCRIPTION
After 189b8895b03ec2ee407c8d951c07230bae3a9a07 we use `GET` instead of `HEAD`