### PR TITLE
FreshRSS widget

### DIFF
--- a/internal/widget/freshrss.go
+++ b/internal/widget/freshrss.go
@@ -1,0 +1,76 @@
+package widget
+
+import (
+	"context"
+	"html/template"
+	"time"
+
+	"github.com/glanceapp/glance/internal/assets"
+	"github.com/glanceapp/glance/internal/feed"
+)
+
+type FreshRSS struct {
+	widgetBase      `yaml:",inline"`
+	FeedRequests    []feed.RSSFeedRequest `yaml:"feeds"`
+	Style           string                `yaml:"style"`
+	ThumbnailHeight float64               `yaml:"thumbnail-height"`
+	CardHeight      float64               `yaml:"card-height"`
+	Items           feed.RSSFeedItems     `yaml:"-"`
+	Limit           int                   `yaml:"limit"`
+	CollapseAfter   int                   `yaml:"collapse-after"`
+	FreshRSSUrl     string                `yaml:"freshrss-url"`
+	FreshRSSUser    string                `yaml:"freshrss-user"`
+	FreshRSSApiPass string                `yaml:"freshrss-api-pass"`
+}
+
+func (widget *FreshRSS) Initialize() error {
+	widget.withTitle("FreshRSS Feed").withCacheDuration(1 * time.Hour)
+
+	if widget.Limit <= 0 {
+		widget.Limit = 25
+	}
+
+	if widget.CollapseAfter == 0 || widget.CollapseAfter < -1 {
+		widget.CollapseAfter = 5
+	}
+
+	if widget.ThumbnailHeight < 0 {
+		widget.ThumbnailHeight = 0
+	}
+
+	if widget.CardHeight < 0 {
+		widget.CardHeight = 0
+	}
+
+	return nil
+}
+
+func (widget *FreshRSS) Update(ctx context.Context) {
+
+	var items feed.RSSFeedItems
+	var err error
+
+	items, err = feed.GetItemsFromFreshRssFeeds(widget.FreshRSSUrl, widget.FreshRSSUser, widget.FreshRSSApiPass)
+
+	if !widget.canContinueUpdateAfterHandlingErr(err) {
+		return
+	}
+
+	if len(items) > widget.Limit {
+		items = items[:widget.Limit]
+	}
+
+	widget.Items = items
+}
+
+func (widget *FreshRSS) Render() template.HTML {
+	if widget.Style == "horizontal-cards" {
+		return widget.render(widget, assets.RSSHorizontalCardsTemplate)
+	}
+
+	if widget.Style == "horizontal-cards-2" {
+		return widget.render(widget, assets.RSSHorizontalCards2Template)
+	}
+
+	return widget.render(widget, assets.RSSListTemplate)
+}

--- a/internal/widget/widget.go
+++ b/internal/widget/widget.go
@@ -41,6 +41,8 @@ func New(widgetType string) (Widget, error) {
 		return &Reddit{}, nil
 	case "rss":
 		return &RSS{}, nil
+	case "freshrss":
+		return &FreshRSS{}, nil
 	case "monitor":
 		return &Monitor{}, nil
 	case "twitch-top-games":


### PR DESCRIPTION
<!--

If your pull request adds new features or changes existing ones please use the latest release/* branch as the base.

Documentation updates (including new themes) can be submitted to the main branch.

-->

Created a FreshRSS widget.  If a glanceapp user is running their own FreshRSS instance, this widget will connect to FreshRSS via its api and get all of their rss feeds. 

### Example:

``` yaml
          - type: freshrss
            freshrss-url: http://freshrss.host.or.ip:port
            freshrss-user: username
            freshrss-api-pass: my-freshrss-api-password
```
