### PR TITLE
feat: added property new-tab to type: search

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -725,10 +725,13 @@ Preview:
 | <kbd>Ctrl</kbd> + <kbd>Enter</kbd> | Perform search in a new tab | Search input is focused and not empty |
 | <kbd>Escape</kbd> | Leave focus | Search input is focused |
 
+If property `new-tab` is set to `true`, keys <kbd>Enter</kbd> and <kbd>Ctrl</kbd> + <kbd>Enter</kbd> will be switched.
+
 #### Properties
 | Name | Type | Required | Default |
 | ---- | ---- | -------- | ------- |
 | search-engine | string | no | duckduckgo |
+| new-tab | boolean | no | false |
 | bangs | array | no | |
 
 ##### `search-engine`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -725,7 +725,9 @@ Preview:
 | <kbd>Ctrl</kbd> + <kbd>Enter</kbd> | Perform search in a new tab | Search input is focused and not empty |
 | <kbd>Escape</kbd> | Leave focus | Search input is focused |
 
-If property `new-tab` is set to `true`, keys <kbd>Enter</kbd> and <kbd>Ctrl</kbd> + <kbd>Enter</kbd> will be switched.
+> [!TIP]
+>
+> You can use the property `new-tab` with a value of `true` if you want to show search results in a new tab by default. <kbd>Ctrl</kbd> + <kbd>Enter</kbd> will then show results in the same tab.
 
 #### Properties
 | Name | Type | Required | Default |
@@ -741,6 +743,9 @@ Either a value from the table below or a URL to a custom search engine. Use `{QU
 | ---- | --- |
 | duckduckgo | `https://duckduckgo.com/?q={QUERY}` |
 | google | `https://www.google.com/search?q={QUERY}` |
+
+##### `new-tab`
+When set to `true`, swaps the shortcuts for showing results in the same or new tab, defaulting to showing results in a new tab.
 
 ##### `bangs`
 What now? [Bangs](https://duckduckgo.com/bangs). They're shortcuts that allow you to use the same search box for many different sites. Assuming you have it configured, if for example you start your search input with `!yt` you'd be able to perform a search on YouTube:

--- a/internal/assets/static/main.css
+++ b/internal/assets/static/main.css
@@ -370,6 +370,10 @@ kbd:active {
     box-shadow: 0 0 0 0 var(--color-widget-background-highlight);
 }
 
+new-tab {
+    display: none;
+}
+
 .content-bounds {
     max-width: 1600px;
     margin-inline: auto;

--- a/internal/assets/static/main.css
+++ b/internal/assets/static/main.css
@@ -370,10 +370,6 @@ kbd:active {
     box-shadow: 0 0 0 0 var(--color-widget-background-highlight);
 }
 
-new-tab {
-    display: none;
-}
-
 .content-bounds {
     max-width: 1600px;
     margin-inline: auto;

--- a/internal/assets/static/main.js
+++ b/internal/assets/static/main.js
@@ -120,6 +120,7 @@ function setupSearchboxes() {
         const inputElement = widget.getElementsByClassName("search-input")[0];
         const bangElement = widget.getElementsByClassName("search-bang")[0];
         const bangs = widget.querySelectorAll(".search-bangs > input");
+        const newTab = widget.getElementsByTagName("new-tab")[0].innerHTML === "true";
         const bangsMap = {};
         const kbdElement = widget.getElementsByTagName("kbd")[0];
         let currentBang = null;
@@ -154,7 +155,7 @@ function setupSearchboxes() {
 
                 const url = searchUrlTemplate.replace("!QUERY!", encodeURIComponent(query));
 
-                if (event.ctrlKey) {
+                if (newTab && !event.ctrlKey || !newTab && event.ctrlKey) {
                     window.open(url, '_blank').focus();
                 } else {
                     window.location.href = url;

--- a/internal/assets/static/main.js
+++ b/internal/assets/static/main.js
@@ -107,7 +107,7 @@ function updateRelativeTimeForElements(elements)
     }
 }
 
-function setupSearchboxes() {
+function setupSearchBoxes() {
     const searchWidgets = document.getElementsByClassName("search");
 
     if (searchWidgets.length == 0) {
@@ -117,10 +117,10 @@ function setupSearchboxes() {
     for (let i = 0; i < searchWidgets.length; i++) {
         const widget = searchWidgets[i];
         const defaultSearchUrl = widget.dataset.defaultSearchUrl;
+        const newTab = widget.dataset.newTab === "true";
         const inputElement = widget.getElementsByClassName("search-input")[0];
         const bangElement = widget.getElementsByClassName("search-bang")[0];
         const bangs = widget.querySelectorAll(".search-bangs > input");
-        const newTab = widget.getElementsByTagName("new-tab")[0].innerHTML === "true";
         const bangsMap = {};
         const kbdElement = widget.getElementsByTagName("kbd")[0];
         let currentBang = null;
@@ -552,7 +552,7 @@ async function setupPage() {
     try {
         setupClocks()
         setupCarousels();
-        setupSearchboxes();
+        setupSearchBoxes();
         setupCollapsibleLists();
         setupCollapsibleGrids();
         setupDynamicRelativeTime();

--- a/internal/assets/templates/search.html
+++ b/internal/assets/templates/search.html
@@ -20,5 +20,6 @@
 
     <div class="search-bang"></div>
     <kbd class="hide-on-mobile" title="Press [S] to focus the search input">S</kbd>
+    <new-tab>{{ .NewTab }}</new-tab>
 </div>
 {{ end }}

--- a/internal/assets/templates/search.html
+++ b/internal/assets/templates/search.html
@@ -3,7 +3,7 @@
 {{ define "widget-content-classes" }}widget-content-frameless{{ end }}
 
 {{ define "widget-content" }}
-<div class="search widget-content-frame padding-inline-widget flex gap-15 items-center" data-default-search-url="{{ .SearchEngine }}">
+<div class="search widget-content-frame padding-inline-widget flex gap-15 items-center" data-default-search-url="{{ .SearchEngine }}" data-new-tab="{{ .NewTab }}">
     <div class="search-bangs">
         {{ range .Bangs }}
         <input type="hidden" data-shortcut="{{ .Shortcut }}" data-title="{{ .Title }}" data-url="{{ .URL }}">
@@ -20,6 +20,5 @@
 
     <div class="search-bang"></div>
     <kbd class="hide-on-mobile" title="Press [S] to focus the search input">S</kbd>
-    <new-tab>{{ .NewTab }}</new-tab>
 </div>
 {{ end }}

--- a/internal/widget/search.go
+++ b/internal/widget/search.go
@@ -19,6 +19,7 @@ type Search struct {
 	cachedHTML   template.HTML `yaml:"-"`
 	SearchEngine string        `yaml:"search-engine"`
 	Bangs        []SearchBang  `yaml:"bangs"`
+	NewTab       bool          `yaml:"new-tab"`
 }
 
 func convertSearchUrl(url string) string {


### PR DESCRIPTION
<!--

If your pull request adds new features or changes existing ones please use the latest release/* branch as the base.

Documentation updates (including new themes) can be submitted to the main branch.

-->

I'm used to having a search bar on a dashboard that opens in a new tab and I kinda prefer it (muscle memory?). Although there is a keyboard shortcut for it, I tend to forget it. This is just a property that is `false` by default and switch the shortcuts if `true`.

This is also my first time with Go, so please do change and optimize things if need be.