### PR TITLE
Rss feed enhance

### DIFF
--- a/internal/feed/rss.go
+++ b/internal/feed/rss.go
@@ -93,7 +93,6 @@ func getItemsFromRSSFeedTask(request RSSFeedRequest) ([]RSSFeedItem, error) {
 
 		rssItem := RSSFeedItem{
 			ChannelURL: feed.Link,
-			Title:      item.Title,
 		}
 
 		if request.ItemLinkPrefix != "" {
@@ -120,8 +119,14 @@ func getItemsFromRSSFeedTask(request RSSFeedRequest) ([]RSSFeedItem, error) {
 			}
 		}
 
+		if item.Title != "" {
+			rssItem.Title = item.Title
+		} else {
+			rssItem.Title = shortenFeedDescriptionLen(item.Description, 100)
+		}
+
 		if request.IsDetailed {
-			if !request.HideDescription && item.Description != "" {
+			if !request.HideDescription && item.Description != "" && item.Title != "" {
 				rssItem.Description = shortenFeedDescriptionLen(item.Description, 200)
 			}
 
@@ -141,10 +146,6 @@ func getItemsFromRSSFeedTask(request RSSFeedRequest) ([]RSSFeedItem, error) {
 				}
 
 				rssItem.Categories = categories
-			}
-		} else {
-			if item.Title == "" {
-				rssItem.Title = shortenFeedDescriptionLen(item.Description, 100)
 			}
 		}
 

--- a/internal/feed/rss.go
+++ b/internal/feed/rss.go
@@ -43,6 +43,18 @@ func sanitizeFeedDescription(description string) string {
 	return description
 }
 
+func shortenFeedDescriptionLen(description string, maxLen int) string {
+	description, _ = limitStringLength(description, 1000)
+	description = sanitizeFeedDescription(description)
+	description, limited := limitStringLength(description, maxLen)
+
+	if limited {
+		description += "…"
+	}
+
+	return description
+}
+
 type RSSFeedRequest struct {
 	Url             string `yaml:"url"`
 	Title           string `yaml:"title"`
@@ -110,15 +122,7 @@ func getItemsFromRSSFeedTask(request RSSFeedRequest) ([]RSSFeedItem, error) {
 
 		if request.IsDetailed {
 			if !request.HideDescription && item.Description != "" {
-				description, _ := limitStringLength(item.Description, 1000)
-				description = sanitizeFeedDescription(description)
-				description, limited := limitStringLength(description, 200)
-
-				if limited {
-					description += "…"
-				}
-
-				rssItem.Description = description
+				rssItem.Description = shortenFeedDescriptionLen(item.Description, 200)
 			}
 
 			if !request.HideCategories {
@@ -137,6 +141,10 @@ func getItemsFromRSSFeedTask(request RSSFeedRequest) ([]RSSFeedItem, error) {
 				}
 
 				rssItem.Categories = categories
+			}
+		} else {
+			if item.Title == "" {
+				rssItem.Title = shortenFeedDescriptionLen(item.Description, 100)
 			}
 		}
 

--- a/internal/feed/rss.go
+++ b/internal/feed/rss.go
@@ -49,6 +49,7 @@ type RSSFeedRequest struct {
 	HideCategories  bool   `yaml:"hide-categories"`
 	HideDescription bool   `yaml:"hide-description"`
 	ItemLinkPrefix  string `yaml:"item-link-prefix"`
+	IsDetailed      bool
 }
 
 type RSSFeedItems []RSSFeedItem
@@ -107,34 +108,36 @@ func getItemsFromRSSFeedTask(request RSSFeedRequest) ([]RSSFeedItem, error) {
 			}
 		}
 
-		if !request.HideDescription && item.Description != "" {
-			description, _ := limitStringLength(item.Description, 1000)
-			description = sanitizeFeedDescription(description)
-			description, limited := limitStringLength(description, 200)
+		if request.IsDetailed {
+			if !request.HideDescription && item.Description != "" {
+				description, _ := limitStringLength(item.Description, 1000)
+				description = sanitizeFeedDescription(description)
+				description, limited := limitStringLength(description, 200)
 
-			if limited {
-				description += "…"
-			}
-
-			rssItem.Description = description
-		}
-
-		if !request.HideCategories {
-			var categories = make([]string, 0, 6)
-
-			for _, category := range item.Categories {
-				if len(categories) == 6 {
-					break
+				if limited {
+					description += "…"
 				}
 
-				if len(category) == 0 || len(category) > 30 {
-					continue
-				}
-
-				categories = append(categories, category)
+				rssItem.Description = description
 			}
 
-			rssItem.Categories = categories
+			if !request.HideCategories {
+				var categories = make([]string, 0, 6)
+
+				for _, category := range item.Categories {
+					if len(categories) == 6 {
+						break
+					}
+
+					if len(category) == 0 || len(category) > 30 {
+						continue
+					}
+
+					categories = append(categories, category)
+				}
+
+				rssItem.Categories = categories
+			}
 		}
 
 		if request.Title != "" {

--- a/internal/feed/rss.go
+++ b/internal/feed/rss.go
@@ -61,7 +61,7 @@ type RSSFeedRequest struct {
 	HideCategories  bool   `yaml:"hide-categories"`
 	HideDescription bool   `yaml:"hide-description"`
 	ItemLinkPrefix  string `yaml:"item-link-prefix"`
-	IsDetailed      bool
+	IsDetailed      bool   `yaml:"-"`
 }
 
 type RSSFeedItems []RSSFeedItem

--- a/internal/widget/rss.go
+++ b/internal/widget/rss.go
@@ -39,10 +39,9 @@ func (widget *RSS) Initialize() error {
 		widget.CardHeight = 0
 	}
 
-	if widget.Style != "detailed-list" {
+	if widget.Style == "detailed-list" {
 		for i := range widget.FeedRequests {
-			widget.FeedRequests[i].HideCategories = true
-			widget.FeedRequests[i].HideDescription = true
+			widget.FeedRequests[i].IsDetailed = true
 		}
 	}
 


### PR DESCRIPTION
Fixed an issue where RSS items without provided titles, such as those from [mastodon](https://mastodon.social/@Mastodon.rss), would not show titles in the RSS list, leading to an absence of navigable links. According to the [RSS specification](https://www.rssboard.org/rss-profile#element-channel-item-title), it is permissible to omit a title. However, this led to a situation where titles were not displayed in the RSS widget, making it impossible to access the corresponding links.

Additionally, the logic for hide-categories and hide-description has been adjusted, so that these settings only affect the display when the style is set to detailed-list.

Before:
![image](https://github.com/glanceapp/glance/assets/35556107/2a1a33e4-1226-477e-9525-0704aaeb7cd6)
After:
![image](https://github.com/glanceapp/glance/assets/35556107/4f9d7d44-eb1b-4af2-87ef-e550ad0516a7)

Example config:
```yaml
pages:
  - name: Test
    columns:
      - size: full
        widgets:
          - type: rss
            limit: 10
            feeds:
              - url: https://mastodon.social/@Mastodon.rss
          - type: rss
            style: detailed-list
            limit: 10
            feeds:
              - url: https://mastodon.social/@Mastodon.rss
      - size: full
        widgets:
          - type: rss
            style: horizontal-cards-1
            limit: 10
            feeds:
              - url: https://mastodon.social/@Mastodon.rss
          - type: rss
            style: horizontal-cards-2
            limit: 10
            feeds:
              - url: https://mastodon.social/@Mastodon.rss
```