### PR TITLE
Fix crash when using a custom CSS file; fix error 404 for manifest.json

### DIFF
--- a/internal/assets/templates/document.html
+++ b/internal/assets/templates/document.html
@@ -13,7 +13,7 @@
     <meta name="theme-color" content="{{ if ne nil .App.Config.Theme.BackgroundColor }}{{ .App.Config.Theme.BackgroundColor }}{{ else }}hsl(240, 8%, 9%){{ end }}">
     <link rel="apple-touch-icon" sizes="512x512" href="{{ .App.AssetPath "app-icon.png" }}">
     <link rel="icon" type="image/png" sizes="50x50" href="{{ .App.AssetPath "favicon.png" }}">
-    <link rel="manifest" href="/static/manifest.json">
+    <link rel="manifest" href="{{ .App.AssetPath "manifest.json" }}">
     <link rel="icon" type="image/png" href="{{ .App.AssetPath "favicon.png" }}" />
     <link rel="stylesheet" href="{{ .App.AssetPath "main.css" }}">
     <script type="module" src="{{ .App.AssetPath "main.js" }}"></script>

--- a/internal/glance/glance.go
+++ b/internal/glance/glance.go
@@ -38,10 +38,11 @@ type Theme struct {
 }
 
 type Server struct {
-	Host       string `yaml:"host"`
-	Port       uint16 `yaml:"port"`
-	AssetsPath string `yaml:"assets-path"`
-	AssetsHash string `yaml:"-"`
+	Host       string    `yaml:"host"`
+	Port       uint16    `yaml:"port"`
+	AssetsPath string    `yaml:"assets-path"`
+	AssetsHash string    `yaml:"-"`
+	StartedAt  time.Time `yaml:"-"` // used in custom css file
 }
 
 type Column struct {
@@ -225,6 +226,7 @@ func (a *Application) Serve() error {
 		Handler: mux,
 	}
 
+	a.Config.Server.StartedAt = time.Now()
 	slog.Info("Starting server", "host", a.Config.Server.Host, "port", a.Config.Server.Port)
 	return server.ListenAndServe()
 }


### PR DESCRIPTION
In release 0.6.0, when using a custom CSS file, backend crashes with error `template: page.html:17:76: executing "document-head-after" at <.App.Config.Server.StartedAt.Unix>: can't evaluate field StartedAt in type glance.Server`.

Also fixed error 404 for manifest.json