### PR TITLE
feat: add no_shorts option for YouTube feeds

### DIFF
--- a/internal/feed/youtube.go
+++ b/internal/feed/youtube.go
@@ -78,12 +78,6 @@ func FetchYoutubeChannelUploads(channelIds []string, videoUrlTemplate string, no
 
 		for j := range response.Videos {
 			video := &response.Videos[j]
-
-			// TODO: figure out a better way of skipping shorts
-			if strings.Contains(video.Title, "#shorts") {
-				continue
-			}
-
 			var videoUrl string
 
 			if videoUrlTemplate == "" {

--- a/internal/feed/youtube.go
+++ b/internal/feed/youtube.go
@@ -39,12 +39,12 @@ func parseYoutubeFeedTime(t string) time.Time {
 	return parsedTime
 }
 
-func FetchYoutubeChannelUploads(channelIds []string, videoUrlTemplate string, noShorts bool) (Videos, error) {
+func FetchYoutubeChannelUploads(channelIds []string, videoUrlTemplate string, includeShorts bool) (Videos, error) {
 	requests := make([]*http.Request, 0, len(channelIds))
 
 	for i := range channelIds {
 		var feedUrl string
-		if noShorts && strings.HasPrefix(channelIds[i], "UC") {
+		if !includeShorts && strings.HasPrefix(channelIds[i], "UC") {
 			playlistId := strings.Replace(channelIds[i], "UC", "UULF", 1)
 			feedUrl = "https://www.youtube.com/feeds/videos.xml?playlist_id=" + playlistId
 		} else {

--- a/internal/feed/youtube.go
+++ b/internal/feed/youtube.go
@@ -10,7 +10,7 @@ import (
 )
 
 type youtubeFeedResponseXml struct {
-	Channel     string `xml:"title"`
+	Channel     string `xml:"author>name"`
 	ChannelLink struct {
 		Href string `xml:"href,attr"`
 	} `xml:"link"`

--- a/internal/feed/youtube.go
+++ b/internal/feed/youtube.go
@@ -39,11 +39,19 @@ func parseYoutubeFeedTime(t string) time.Time {
 	return parsedTime
 }
 
-func FetchYoutubeChannelUploads(channelIds []string, videoUrlTemplate string) (Videos, error) {
+func FetchYoutubeChannelUploads(channelIds []string, videoUrlTemplate string, noShorts bool) (Videos, error) {
 	requests := make([]*http.Request, 0, len(channelIds))
 
 	for i := range channelIds {
-		request, _ := http.NewRequest("GET", "https://www.youtube.com/feeds/videos.xml?channel_id="+channelIds[i], nil)
+		var feedUrl string
+		if noShorts && strings.HasPrefix(channelIds[i], "UC") {
+			playlistId := strings.Replace(channelIds[i], "UC", "UULF", 1)
+			feedUrl = "https://www.youtube.com/feeds/videos.xml?playlist_id=" + playlistId
+		} else {
+			feedUrl = "https://www.youtube.com/feeds/videos.xml?channel_id=" + channelIds[i]
+		}
+
+		request, _ := http.NewRequest("GET", feedUrl, nil)
 		requests = append(requests, request)
 	}
 

--- a/internal/widget/videos.go
+++ b/internal/widget/videos.go
@@ -17,6 +17,7 @@ type Videos struct {
 	CollapseAfterRows int         `yaml:"collapse-after-rows"`
 	Channels          []string    `yaml:"channels"`
 	Limit             int         `yaml:"limit"`
+	NoShorts          bool        `yaml:"no_shorts"`
 }
 
 func (widget *Videos) Initialize() error {
@@ -34,7 +35,7 @@ func (widget *Videos) Initialize() error {
 }
 
 func (widget *Videos) Update(ctx context.Context) {
-	videos, err := feed.FetchYoutubeChannelUploads(widget.Channels, widget.VideoUrlTemplate)
+	videos, err := feed.FetchYoutubeChannelUploads(widget.Channels, widget.VideoUrlTemplate, widget.NoShorts)
 
 	if !widget.canContinueUpdateAfterHandlingErr(err) {
 		return

--- a/internal/widget/videos.go
+++ b/internal/widget/videos.go
@@ -17,7 +17,7 @@ type Videos struct {
 	CollapseAfterRows int         `yaml:"collapse-after-rows"`
 	Channels          []string    `yaml:"channels"`
 	Limit             int         `yaml:"limit"`
-	NoShorts          bool        `yaml:"no_shorts"`
+	IncludeShorts     bool        `yaml:"include-shorts"`
 }
 
 func (widget *Videos) Initialize() error {
@@ -35,7 +35,7 @@ func (widget *Videos) Initialize() error {
 }
 
 func (widget *Videos) Update(ctx context.Context) {
-	videos, err := feed.FetchYoutubeChannelUploads(widget.Channels, widget.VideoUrlTemplate, widget.NoShorts)
+	videos, err := feed.FetchYoutubeChannelUploads(widget.Channels, widget.VideoUrlTemplate, widget.IncludeShorts)
 
 	if !widget.canContinueUpdateAfterHandlingErr(err) {
 		return


### PR DESCRIPTION
This adds a `no_shorts` option for YouTube feeds.
It works by using the default video playlist feed instead of the channel feed.
I find it very hard to express how much I hate YouTube shorts.

It would be cleaner to add support to "playlists" along with "channels", so that users could add whatever built-in/custom playlist they wish, but  I feel wanting to remove shorts is something so common that it should be handled automatically.

Related issues (pinging some other people):
- https://github.com/glanceapp/glance/issues/106
- https://github.com/FreshRSS/Extensions/issues/234
- https://github.com/Ranchero-Software/NetNewsWire/issues/3975