### PR TITLE
Different monitor urls

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -997,7 +997,7 @@ Properties for each site:
 | ---- | ---- | -------- | ------- |
 | title | string | yes | |
 | url | string | yes | |
-| check_url | string | no | |
+| check-url | string | no | |
 | icon | string | no | |
 | allow-insecure | boolean | no | false |
 | same-tab | boolean | no | false |
@@ -1008,9 +1008,9 @@ The title used to indicate the site.
 
 `url`
 
-The public facing URL of a monitored service, the user will be redirected here. If `check_url` is not specified, this is used as the status check.
+The public facing URL of a monitored service, the user will be redirected here. If `check-url` is not specified, this is used as the status check.
 
-`check_url`
+`check-url`
 
 The URL which will be requested and its response will determine the status of the site. If not specified, the `url` property is used.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -997,6 +997,7 @@ Properties for each site:
 | ---- | ---- | -------- | ------- |
 | title | string | yes | |
 | url | string | yes | |
+| check_url | string | no | |
 | icon | string | no | |
 | allow-insecure | boolean | no | false |
 | same-tab | boolean | no | false |
@@ -1007,7 +1008,11 @@ The title used to indicate the site.
 
 `url`
 
-The URL which will be requested and its response will determine the status of the site. Optionally, you can specify this using an environment variable with the syntax `${VARIABLE_NAME}`.
+The public facing URL of a monitored service, the user will be redirected here. If `check_url` is not specified, this is used as the status check.
+
+`check_url`
+
+The URL which will be requested and its response will determine the status of the site. If not specified, the `url` property is used.
 
 `icon`
 

--- a/internal/feed/monitor.go
+++ b/internal/feed/monitor.go
@@ -21,7 +21,13 @@ type SiteStatus struct {
 }
 
 func getSiteStatusTask(statusRequest *SiteStatusRequest) (SiteStatus, error) {
-	request, err := http.NewRequest(http.MethodGet, statusRequest.CheckURL, nil)
+	var url string
+	if statusRequest.CheckURL != "" {
+		url = statusRequest.CheckURL
+	} else {
+		url = statusRequest.URL
+	}
+	request, err := http.NewRequest(http.MethodGet, url, nil)
 
 	if err != nil {
 		return SiteStatus{

--- a/internal/feed/monitor.go
+++ b/internal/feed/monitor.go
@@ -9,6 +9,7 @@ import (
 
 type SiteStatusRequest struct {
 	URL           string `yaml:"url"`
+	CheckURL      string `yaml:"check_url"`
 	AllowInsecure bool   `yaml:"allow-insecure"`
 }
 
@@ -20,7 +21,7 @@ type SiteStatus struct {
 }
 
 func getSiteStatusTask(statusRequest *SiteStatusRequest) (SiteStatus, error) {
-	request, err := http.NewRequest(http.MethodGet, statusRequest.URL, nil)
+	request, err := http.NewRequest(http.MethodGet, statusRequest.CheckURL, nil)
 
 	if err != nil {
 		return SiteStatus{

--- a/internal/feed/monitor.go
+++ b/internal/feed/monitor.go
@@ -9,7 +9,7 @@ import (
 
 type SiteStatusRequest struct {
 	URL           string `yaml:"url"`
-	CheckURL      string `yaml:"check_url"`
+	CheckURL      string `yaml:"check-url"`
 	AllowInsecure bool   `yaml:"allow-insecure"`
 }
 


### PR DESCRIPTION
Add different monitor URL for UI link and actual status checking. See corressponding issue: #154 

I would like to receive feedback on the correctness of how I handled the fallback when `check_url` is not provided, I'm not familiar how Go Yaml handles missing properties.