### PR TITLE
CSS dynamic columns refactor and made more widgets compatible with them

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1043,13 +1043,18 @@ You can hover over the "ERROR" text to view more information.
 
 #### Properties
 
-| Name | Type | Required |
-| ---- | ---- | -------- |
-| sites | array | yes |
-| style | string | no |
+| Name | Type | Required | Default |
+| ---- | ---- | -------- |---------|
+| sites | array | yes | |
+| collapse-after | integer | no | 5 |
+| style | string | no | |
 
 ##### `style`
 To make the widget scale appropriately in a `full` size column, set the style to the experimental `dynamic-columns-experimental` option.
+
+##### `collapse-after`
+
+How many sites are visible before the "SHOW MORE" button appears. Set to `-1` to never collapse.
 
 ##### `sites`
 
@@ -1128,6 +1133,7 @@ Preview:
 | gitlab-token | string | no | |
 | limit | integer | no | 10 |
 | collapse-after | integer | no | 5 |
+| style | string | no | |
 
 ##### `repositories`
 A list of repositores to fetch the latest release for. Only the name/repo is required, not the full URL. A prefix can be specified for repositories hosted elsewhere such as GitLab and Docker Hub. Example:
@@ -1190,6 +1196,9 @@ The maximum number of releases to show.
 
 #### `collapse-after`
 How many releases are visible before the "SHOW MORE" button appears. Set to `-1` to never collapse.
+
+##### `style`
+To make the widget scale appropriately in a `full` size column, set the style to the experimental `dynamic-columns-experimental` option.
 
 ### Repository
 Display general information about a repository as well as a list of the latest open pull requests and issues.
@@ -1347,6 +1356,7 @@ Preview:
 | limit | integer | no | 10 |
 | collapse-after | integer | no | 5 |
 | watches | array of strings | no |  |
+| style | string | no |  |
 
 ##### `instance-url`
 The URL pointing to your instance of `changedetection.io`.
@@ -1369,6 +1379,9 @@ By default all of the configured watches will be shown. Optionally, you can spec
       - 1abca041-6d4f-4554-aa19-809147f538d3
       - 705ed3e4-ea86-4d25-a064-822a6425be2c
 ```
+
+##### `style`
+To make the widget scale appropriately in a `full` size column, set the style to the experimental `dynamic-columns-experimental` option.
 
 ### Clock
 Display a clock showing the current time and date. Optionally, also display the the time in other timezones.
@@ -1521,6 +1534,7 @@ Preview:
 | channels | array | yes | |
 | collapse-after | integer | no | 5 |
 | sort-by | string | no | viewers |
+| style | string | no | |
 
 ##### `channels`
 A list of channels to display.
@@ -1530,6 +1544,9 @@ How many channels are visible before the "SHOW MORE" button appears. Set to `-1`
 
 ##### `sort-by`
 Can be used to specify the order in which the channels are displayed. Possible values are `viewers` and `live`.
+
+##### `style`
+To make the widget scale appropriately in a `full` size column, set the style to the experimental `dynamic-columns-experimental` option.
 
 ### Twitch top games
 Display a list of games with the most viewers on Twitch.
@@ -1556,6 +1573,7 @@ Preview:
 | exclude | array | no | |
 | limit | integer | no | 10 |
 | collapse-after | integer | no | 5 |
+| style | string | no | |
 
 ##### `exclude`
 A list of categories that will never be shown. You must provide the slug found by clicking on the category and looking at the URL:
@@ -1570,6 +1588,9 @@ The maximum number of games to show.
 
 ##### `collapse-after`
 How many games are visible before the "SHOW MORE" button appears. Set to `-1` to never collapse.
+
+##### `style`
+To make the widget scale appropriately in a `full` size column, set the style to the experimental `dynamic-columns-experimental` option.
 
 ### iframe
 Embed an iframe as a widget.

--- a/internal/assets/static/main.css
+++ b/internal/assets/static/main.css
@@ -460,33 +460,44 @@ kbd:active {
 
 .dynamic-columns > * {
     padding: calc(var(--widget-content-vertical-padding) / 2) calc(var(--widget-content-horizontal-padding) / 1.5);
-    background-color: var(--color-background);
-    border-radius: var(--border-radius);
+    border-top: 1px solid var(--color-separator);
+    border-left: 1px solid var(--color-separator);
+}
+.dynamic-columns > *:first-child {
+    border-top: none;
+    border-left: none;
 }
 
-.dynamic-columns:has(> :nth-child(1)) { --columns-per-row: 1; }
-.dynamic-columns:has(> :nth-child(2)) { --columns-per-row: 2; }
-.dynamic-columns:has(> :nth-child(3)) { --columns-per-row: 3; }
-.dynamic-columns:has(> :nth-child(4)) { --columns-per-row: 4; }
-.dynamic-columns:has(> :nth-child(5)) { --columns-per-row: 5; }
-
-@container widget (max-width: 1500px) {
-    .dynamic-columns:has(> :nth-child(1)) { --columns-per-row: 1; }
-    .dynamic-columns:has(> :nth-child(2)) { --columns-per-row: 2; }
-    .dynamic-columns:has(> :nth-child(3)) { --columns-per-row: 3; }
-    .dynamic-columns:has(> :nth-child(4)) { --columns-per-row: 4; }
+@container widget (max-width: 449px) {
+    .dynamic-columns { --columns-per-row: 1; }
+    .dynamic-columns > * {
+        border-left: none;
+        padding-bottom: calc(var(--widget-content-vertical-padding) / -2);
+    }
 }
-@container widget (max-width: 1250px) {
-    .dynamic-columns:has(> :nth-child(1)) { --columns-per-row: 1; }
-    .dynamic-columns:has(> :nth-child(2)) { --columns-per-row: 2; }
-    .dynamic-columns:has(> :nth-child(3)) { --columns-per-row: 3; }
+@container widget (min-width: 450px) and (max-width: 850px) {
+    .dynamic-columns { --columns-per-row: 2; }
+    .dynamic-columns > * { border-top: none; }
+    .dynamic-columns > :nth-child(-n+2) { border-top: none; }
+    .dynamic-columns > :nth-child(2n-1) { border-left: none; }
 }
-@container widget (max-width: 850px) {
-    .dynamic-columns:has(> :nth-child(1)) { --columns-per-row: 1; }
-    .dynamic-columns:has(> :nth-child(2)) { --columns-per-row: 2; }
+@container widget (min-width: 849px) and (max-width: 1250px) {
+    .dynamic-columns { --columns-per-row: 3; }
+    .dynamic-columns > * { border-top: none; }
+    .dynamic-columns > :nth-child(-n+3) { border-top: none; }
+    .dynamic-columns > :nth-child(3n+1) { border-left: none; }
 }
-@container widget (max-width: 550px) {
-    .dynamic-columns:has(> :nth-child(1)) { --columns-per-row: 1; }
+@container widget (min-width: 1249px) and (max-width: 1499px) {
+    .dynamic-columns { --columns-per-row: 4; }
+    .dynamic-columns > * { border-top: none; }
+    .dynamic-columns > :nth-child(-n+4) { border-top: none; }
+    .dynamic-columns > :nth-child(4n+1) { border-left: none; }
+}
+@container widget (min-width: 1500px) {
+    .dynamic-columns { --columns-per-row: 5; }
+    .dynamic-columns > * { border-top: none; }
+    .dynamic-columns > :nth-child(-n+5) { border-top: none; }
+    .dynamic-columns > :nth-child(5n+1) { border-left: none; }
 }
 
 .cards-vertical {
@@ -1410,8 +1421,6 @@ kbd:active {
         --widget-content-horizontal-padding: 10px;
         --content-bounds-padding: 10px;
     }
-
-    .dynamic-columns:has(> :nth-child(1)) { --columns-per-row: 1; }
 
     .row-reverse-on-mobile {
         flex-direction: row-reverse;

--- a/internal/assets/static/main.css
+++ b/internal/assets/static/main.css
@@ -468,33 +468,39 @@ kbd:active {
     border-left: none;
 }
 
+.dynamic-columns:has(> :nth-child(1)) { --columns-per-row: 1; }
+.dynamic-columns:has(> :nth-child(2)) { --columns-per-row: 2; }
+.dynamic-columns:has(> :nth-child(3)) { --columns-per-row: 3; }
+.dynamic-columns:has(> :nth-child(4)) { --columns-per-row: 4; }
+.dynamic-columns:has(> :nth-child(5)) { --columns-per-row: 5; }
+
 @container widget (max-width: 449px) {
-    .dynamic-columns { --columns-per-row: 1; }
+    .dynamic-columns:has(> :nth-child(1)) { --columns-per-row: 1; }
     .dynamic-columns > * {
         border-left: none;
         padding-bottom: calc(var(--widget-content-vertical-padding) / -2);
     }
 }
 @container widget (min-width: 450px) and (max-width: 850px) {
-    .dynamic-columns { --columns-per-row: 2; }
+    .dynamic-columns:has(> :nth-child(2)) { --columns-per-row: 2; }
     .dynamic-columns > * { border-top: none; }
     .dynamic-columns > :nth-child(-n+2) { border-top: none; }
     .dynamic-columns > :nth-child(2n-1) { border-left: none; }
 }
 @container widget (min-width: 849px) and (max-width: 1250px) {
-    .dynamic-columns { --columns-per-row: 3; }
+    .dynamic-columns:has(> :nth-child(3)) { --columns-per-row: 3; }
     .dynamic-columns > * { border-top: none; }
     .dynamic-columns > :nth-child(-n+3) { border-top: none; }
     .dynamic-columns > :nth-child(3n+1) { border-left: none; }
 }
 @container widget (min-width: 1249px) and (max-width: 1499px) {
-    .dynamic-columns { --columns-per-row: 4; }
+    .dynamic-columns:has(> :nth-child(4)) { --columns-per-row: 4; }
     .dynamic-columns > * { border-top: none; }
     .dynamic-columns > :nth-child(-n+4) { border-top: none; }
     .dynamic-columns > :nth-child(4n+1) { border-left: none; }
 }
 @container widget (min-width: 1500px) {
-    .dynamic-columns { --columns-per-row: 5; }
+    .dynamic-columns:has(> :nth-child(5)) { --columns-per-row: 5; }
     .dynamic-columns > * { border-top: none; }
     .dynamic-columns > :nth-child(-n+5) { border-top: none; }
     .dynamic-columns > :nth-child(5n+1) { border-left: none; }

--- a/internal/assets/static/main.js
+++ b/internal/assets/static/main.js
@@ -365,8 +365,8 @@ function attachExpandToggleButton(collapsibleContainer) {
 };
 
 
-function setupCollapsibleLists() {
-    const collapsibleLists = document.querySelectorAll(".list.collapsible-container");
+function setupCollapsibleLists(selector) {
+    const collapsibleLists = document.querySelectorAll(selector);
 
     if (collapsibleLists.length == 0) {
         return;
@@ -596,7 +596,8 @@ async function setupPage() {
         setupClocks()
         setupCarousels();
         setupSearchBoxes();
-        setupCollapsibleLists();
+        setupCollapsibleLists(".list.collapsible-container");
+        setupCollapsibleLists(".dynamic-columns.collapsible-container");
         setupCollapsibleGrids();
         setupGroups();
         setupDynamicRelativeTime();

--- a/internal/assets/templates.go
+++ b/internal/assets/templates.go
@@ -66,6 +66,9 @@ var globalTemplateFunctions = template.FuncMap{
 	"dynamicRelativeTimeAttrs": func(t time.Time) template.HTMLAttr {
 		return template.HTMLAttr(fmt.Sprintf(`data-dynamic-relative-time="%d"`, t.Unix()))
 	},
+	"params": func(p ...any) []any {
+		return p
+	},
 }
 
 func compileTemplate(primary string, dependencies ...string) *template.Template {

--- a/internal/assets/templates/change-detection.html
+++ b/internal/assets/templates/change-detection.html
@@ -1,17 +1,33 @@
 {{ template "widget-base.html" . }}
 
 {{ define "widget-content" }}
+{{ if ne .Style "dynamic-columns-experimental" }}
 <ul class="list list-gap-14 collapsible-container" data-collapse-after="{{ .CollapseAfter }}">
     {{ range .ChangeDetections }}
     <li>
-        <a class="size-h4 block text-truncate color-highlight" href="{{ .URL }}" target="_blank" rel="noreferrer">{{ .Title }}</a>
-        <ul class="list-horizontal-text">
-            <li {{ dynamicRelativeTimeAttrs .LastChanged }}></li>
-            <li class="shrink min-width-0"><a class="visited-indicator" href="{{ .DiffURL }}" target="_blank" rel="noreferrer">diff:{{ .PreviousHash }}</a></li>
-        </ul>
+        {{ template "change-detection" . }}
     </li>
     {{ else }}
     <li>No watches configured</li>
-    {{ end}}
+    {{ end }}
+</ul>
+{{ else }}
+<ul class="dynamic-columns">
+  {{ range .ChangeDetections }}
+  <li class="flex flex-column gap-5">
+    {{ template "change-detection" . }}
+  </li>
+  {{ else }}
+  <li>No watches configured</li>
+  {{ end }}
+</ul>
+{{ end }}
+{{ end }}
+
+{{ define "change-detection" }}
+<a class="size-h4 block text-truncate color-highlight" href="{{ .URL }}" target="_blank" rel="noreferrer">{{ .Title }}</a>
+<ul class="list-horizontal-text">
+  <li {{ dynamicRelativeTimeAttrs .LastChanged }}></li>
+  <li class="shrink min-width-0"><a class="visited-indicator" href="{{ .DiffURL }}" target="_blank" rel="noreferrer">diff:{{ .PreviousHash }}</a></li>
 </ul>
 {{ end }}

--- a/internal/assets/templates/change-detection.html
+++ b/internal/assets/templates/change-detection.html
@@ -12,7 +12,7 @@
     {{ end }}
 </ul>
 {{ else }}
-<ul class="dynamic-columns">
+<ul class="dynamic-columns collapsible-container" data-collapse-after="{{ .CollapseAfter }}">
   {{ range .ChangeDetections }}
   <li class="flex flex-column gap-5">
     {{ template "change-detection" . }}

--- a/internal/assets/templates/monitor.html
+++ b/internal/assets/templates/monitor.html
@@ -2,7 +2,7 @@
 
 {{ define "widget-content" }}
 {{ if ne .Style "dynamic-columns-experimental" }}
-<ul class="list list-gap-20 list-with-separator">
+<ul class="list list-gap-20 list-with-separator" data-collapse-after="{{ .CollapseAfter }}">
     {{ range .Sites }}
     <li class="monitor-site flex items-center gap-15">
         {{ template "site" . }}
@@ -10,7 +10,7 @@
     {{ end }}
 </ul>
 {{ else }}
-<ul class="dynamic-columns">
+<ul class="dynamic-columns collapsible-container" data-collapse-after="{{ .CollapseAfter }}">
     {{ range .Sites }}
     <div class="flex items-center gap-15">
         {{ template "site" . }}

--- a/internal/assets/templates/releases.html
+++ b/internal/assets/templates/releases.html
@@ -1,23 +1,40 @@
 {{ template "widget-base.html" . }}
 
 {{ define "widget-content" }}
+{{ if ne .Style "dynamic-columns-experimental" }}
 <ul class="list list-gap-10 collapsible-container" data-collapse-after="{{ .CollapseAfter }}">
-    {{ range .Releases }}
-    <li>
-        <div class="flex items-center gap-10">
-            <a class="size-h4 block text-truncate color-primary-if-not-visited" href="{{ .NotesUrl }}" target="_blank" rel="noreferrer">{{ .Name }}</a>
-            {{ if $.ShowSourceIcon }}
-            <img class="simple-icon release-source-icon" src="{{ .SourceIconURL }}" alt="" loading="lazy">
-            {{ end }}
-        </div>
-        <ul class="list-horizontal-text">
-            <li {{ dynamicRelativeTimeAttrs .TimeReleased }}></li>
-            <li>{{ .Version }}</li>
-            {{ if gt .Downvotes 3 }}
-            <li>{{ .Downvotes | formatNumber }} ⚠</li>
-            {{ end }}
-        </ul>
-    </li>
-    {{ end }}
+  {{ range .Releases }}
+  <li>
+    {{ template "release" (params . $.ShowSourceIcon) }}
+  </li>
+  {{ end }}
+</ul>
+{{ else }}
+<ul class="dynamic-columns collapsible-container" data-collapse-after="{{ .CollapseAfter }}">
+  {{ range .Releases }}
+  <li class="flex flex-column gap-5">
+    {{ template "release" (params . $.ShowSourceIcon) }}
+  </li>
+  {{ end }}
+</ul>
+{{ end }}
+{{ end }}
+
+
+{{ define "release" }}
+{{ $rel := index . 0 }}
+{{ $showSourceIcon := index . 1 }}
+<div class="flex items-center gap-10">
+  <a class="size-h4 block text-truncate color-primary-if-not-visited" href="{{ $rel.NotesUrl }}" target="_blank" rel="noreferrer">{{ $rel.Name }}</a>
+  {{ if $showSourceIcon }}
+  <img class="simple-icon release-source-icon" src="{{ $rel.SourceIconURL }}" alt="" loading="lazy">
+  {{ end }}
+</div>
+<ul class="list-horizontal-text">
+  <li {{ dynamicRelativeTimeAttrs $rel.TimeReleased }}></li>
+  <li>{{ $rel.Version }}</li>
+  {{ if gt $rel.Downvotes 3 }}
+  <li>{{ $rel.Downvotes | formatNumber }} ⚠</li>
+  {{ end }}
 </ul>
 {{ end }}

--- a/internal/assets/templates/twitch-channels.html
+++ b/internal/assets/templates/twitch-channels.html
@@ -10,7 +10,7 @@
   {{ end }}
 </ul>
 {{ else }}
-<ul class="dynamic-columns">
+<ul class="dynamic-columns collapsible-container" data-collapse-after="{{ .CollapseAfter }}">
     {{ range .Channels }}
     <li class="flex flex-column gap-5">
         {{ template "twitch-channel" . }}

--- a/internal/assets/templates/twitch-channels.html
+++ b/internal/assets/templates/twitch-channels.html
@@ -1,41 +1,55 @@
 {{ template "widget-base.html" . }}
 
 {{ define "widget-content" }}
+{{ if ne .Style "dynamic-columns-experimental" }}
 <ul class="list list-gap-14 collapsible-container" data-collapse-after="{{ .CollapseAfter }}">
     {{ range .Channels }}
     <li>
-        <div class="{{ if .IsLive }}twitch-channel-live {{ end }}flex gap-10 items-start thumbnail-parent">
-            <div class="twitch-channel-avatar-container">
-                {{ if .Exists }}
-                <a href="https://twitch.tv/{{ .Login }}" class="twitch-channel-avatar-link" target="_blank" rel="noreferrer">
-                    <img class="twitch-channel-avatar thumbnail" src="{{ .AvatarUrl }}" alt="" loading="lazy">
-                </a>
-                {{ else }}
-                <svg class="twitch-channel-avatar thumbnail" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
-                </svg>
-                {{ end }}
-            </div>
-            <div class="min-width-0">
-                <a href="https://twitch.tv/{{ .Login }}" class="size-h3{{ if .IsLive }} color-highlight{{ end }} block text-truncate" target="_blank" rel="noreferrer">{{ .Name }}</a>
-                {{ if .Exists }}
-                    {{ if .IsLive }}
-                        {{ if .Category }}
-                            <a class="text-truncate block" href="https://www.twitch.tv/directory/category/{{ .CategorySlug }}" target="_blank" rel="noreferrer">{{ .Category }}</a>
-                        {{ end }}
-                    <ul class="list-horizontal-text">
-                        <li {{ dynamicRelativeTimeAttrs .LiveSince }}></li>
-                        <li>{{ .ViewersCount | formatViewerCount }} viewers</li>
-                    </ul>
-                    {{ else }}
-                    <div>Offline</div>
-                    {{ end }}
-                {{ else }}
-                <div class="color-negative">Not found</div>
-                {{ end }}
-            </div>
-        </div>
+      {{ template "twitch-channel" . }}
+    </li>
+  {{ end }}
+</ul>
+{{ else }}
+<ul class="dynamic-columns">
+    {{ range .Channels }}
+    <li class="flex flex-column gap-5">
+        {{ template "twitch-channel" . }}
     </li>
     {{ end }}
 </ul>
+{{ end }}
+{{ end }}
+
+{{ define "twitch-channel" }}
+<div class="{{ if .IsLive }}twitch-channel-live {{ end }}flex gap-10 items-start thumbnail-parent">
+    <div class="twitch-channel-avatar-container">
+        {{ if .Exists }}
+        <a href="https://twitch.tv/{{ .Login }}" class="twitch-channel-avatar-link" target="_blank" rel="noreferrer">
+            <img class="twitch-channel-avatar thumbnail" src="{{ .AvatarUrl }}" alt="" loading="lazy">
+        </a>
+        {{ else }}
+        <svg class="twitch-channel-avatar thumbnail" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+        </svg>
+        {{ end }}
+    </div>
+    <div class="min-width-0">
+        <a href="https://twitch.tv/{{ .Login }}" class="size-h3{{ if .IsLive }} color-highlight{{ end }} block text-truncate" target="_blank" rel="noreferrer">{{ .Name }}</a>
+        {{ if .Exists }}
+            {{ if .IsLive }}
+                {{ if .Category }}
+                    <a class="text-truncate block" href="https://www.twitch.tv/directory/category/{{ .CategorySlug }}" target="_blank" rel="noreferrer">{{ .Category }}</a>
+                {{ end }}
+            <ul class="list-horizontal-text">
+                <li {{ dynamicRelativeTimeAttrs .LiveSince }}></li>
+                <li>{{ .ViewersCount | formatViewerCount }} viewers</li>
+            </ul>
+            {{ else }}
+            <div>Offline</div>
+            {{ end }}
+        {{ else }}
+        <div class="color-negative">Not found</div>
+        {{ end }}
+    </div>
+</div>
 {{ end }}

--- a/internal/assets/templates/twitch-games-list.html
+++ b/internal/assets/templates/twitch-games-list.html
@@ -10,7 +10,7 @@
   {{ end }}
 </ul>
 {{ else }}
-<ul class="dynamic-columns">
+<ul class="dynamic-columns collapsible-container" data-collapse-after="{{ .CollapseAfter }}">
     {{ range .Categories }}
     <li class="flex flex-column gap-5">
         {{ template "twitch-category" . }}

--- a/internal/assets/templates/twitch-games-list.html
+++ b/internal/assets/templates/twitch-games-list.html
@@ -1,31 +1,49 @@
 {{ template "widget-base.html" . }}
 
 {{ define "widget-content" }}
+{{ if ne .Style "dynamic-columns-experimental" }}
 <ul class="list list-gap-14 collapsible-container" data-collapse-after="{{ .CollapseAfter }}">
+  {{ range .Categories }}
+  <li>
+      {{ template "twitch-category" . }}
+  </li>
+  {{ end }}
+</ul>
+{{ else }}
+<ul class="dynamic-columns">
     {{ range .Categories }}
-    <li class="twitch-category thumbnail-parent">
-        <div class="flex gap-10 items-start">
-            <img class="twitch-category-thumbnail thumbnail" loading="lazy" src="{{ .AvatarUrl }}" alt="">
-            <div class="min-width-0">
-                <a class="size-h3 color-highlight text-truncate block" href="https://www.twitch.tv/directory/category/{{ .Slug }}" target="_blank" rel="noreferrer">{{ .Name }}</a>
-                <ul class="list-horizontal-text">
-                    <li>{{ .ViewersCount | formatViewerCount }} viewers</li>
-                    {{ if .IsNew }}
-                    <li class="color-primary">NEW</li>
-                    {{ end }}
-                </ul>
-                <ul class="list-horizontal-text flex-nowrap">
-                    {{ range $i, $tag := .Tags }}
-                        {{ if eq $i 0 }}
-                        <li class="shrink-0">{{ $tag.Name }}</li>
-                        {{ else }}
-                        <li class="text-truncate min-width-0">{{ $tag.Name }}</li>
-                        {{ end }}
-                    {{ end }}
-                </ul>
-            </div>
-        </div>
+    <li class="flex flex-column gap-5">
+        {{ template "twitch-category" . }}
     </li>
     {{ end }}
 </ul>
+{{ end }}
+{{ end }}
+
+{{ define "twitch-category" }}
+<div class="twitch-category thumbnail-parent">
+  <div class="flex gap-10 items-start">
+    <a href="https://www.twitch.tv/directory/category/{{ .Slug }}" target="_blank" rel="noreferrer">
+      <img class="twitch-category-thumbnail thumbnail" loading="lazy" src="{{ .AvatarUrl }}" alt="">
+    </a>
+    <div class="min-width-0">
+      <a class="size-h3 color-highlight text-truncate block" href="https://www.twitch.tv/directory/category/{{ .Slug }}" target="_blank" rel="noreferrer">{{ .Name }}</a>
+      <ul class="list-horizontal-text">
+        <li>{{ .ViewersCount | formatViewerCount }} viewers</li>
+        {{ if .IsNew }}
+        <li class="color-primary">NEW</li>
+        {{ end }}
+      </ul>
+      <ul class="list-horizontal-text flex-nowrap">
+        {{ range $i, $tag := .Tags }}
+          {{ if eq $i 0 }}
+          <li class="shrink-0">{{ $tag.Name }}</li>
+          {{ else }}
+          <li class="text-truncate min-width-0">{{ $tag.Name }}</li>
+          {{ end }}
+        {{ end }}
+      </ul>
+    </div>
+  </div>
+</div>
 {{ end }}

--- a/internal/widget/changedetection.go
+++ b/internal/widget/changedetection.go
@@ -17,6 +17,7 @@ type ChangeDetection struct {
 	Token            OptionalEnvString           `yaml:"token"`
 	Limit            int                         `yaml:"limit"`
 	CollapseAfter    int                         `yaml:"collapse-after"`
+	Style            string                      `yaml:"style"`
 }
 
 func (widget *ChangeDetection) Initialize() error {

--- a/internal/widget/monitor.go
+++ b/internal/widget/monitor.go
@@ -53,11 +53,16 @@ type Monitor struct {
 		StatusText              string           `yaml:"-"`
 		StatusStyle             string           `yaml:"-"`
 	} `yaml:"sites"`
-	Style string `yaml:"style"`
+	Style         string `yaml:"style"`
+	CollapseAfter int    `yaml:"collapse-after"`
 }
 
 func (widget *Monitor) Initialize() error {
 	widget.withTitle("Monitor").withCacheDuration(5 * time.Minute)
+
+	if widget.CollapseAfter == 0 || widget.CollapseAfter < -1 {
+		widget.CollapseAfter = 5
+	}
 
 	for i := range widget.Sites {
 		widget.Sites[i].IconUrl, widget.Sites[i].IsSimpleIcon = toSimpleIconIfPrefixed(widget.Sites[i].IconUrl)

--- a/internal/widget/releases.go
+++ b/internal/widget/releases.go
@@ -21,6 +21,7 @@ type Releases struct {
 	Limit           int                    `yaml:"limit"`
 	CollapseAfter   int                    `yaml:"collapse-after"`
 	ShowSourceIcon  bool                   `yaml:"show-source-icon"`
+	Style           string                 `yaml:"style"`
 }
 
 func (widget *Releases) Initialize() error {

--- a/internal/widget/twitch-channels.go
+++ b/internal/widget/twitch-channels.go
@@ -15,6 +15,7 @@ type TwitchChannels struct {
 	Channels        []feed.TwitchChannel `yaml:"-"`
 	CollapseAfter   int                  `yaml:"collapse-after"`
 	SortBy          string               `yaml:"sort-by"`
+	Style           string               `yaml:"style"`
 }
 
 func (widget *TwitchChannels) Initialize() error {

--- a/internal/widget/twitch-top-games.go
+++ b/internal/widget/twitch-top-games.go
@@ -15,6 +15,7 @@ type TwitchGames struct {
 	Exclude       []string              `yaml:"exclude"`
 	Limit         int                   `yaml:"limit"`
 	CollapseAfter int                   `yaml:"collapse-after"`
+	Style         string                `yaml:"style"`
 }
 
 func (widget *TwitchGames) Initialize() error {


### PR DESCRIPTION
I cleaned up some CSS code related to dynamic columns classes and made Github releases, Changedetection, monitor, Twitch channels and categories widgets compatible with `dynamic-columns-experimental`

Some previews:
<details>
  <summary>One column sample</summary>

![1c](https://github.com/user-attachments/assets/6d1eb505-6eaa-4f73-bc37-2e793d071fcf)
</details>
<details>
  <summary>5 columns sample</summary>

![5c](https://github.com/user-attachments/assets/eb7c6639-a3c7-4f47-9f80-45cd2974c3f8)
</details>
