### PR TITLE
Fix RSS item link empty <link/>

### DIFF
--- a/internal/feed/rss.go
+++ b/internal/feed/rss.go
@@ -98,7 +98,7 @@ func getItemsFromRSSFeedTask(request RSSFeedRequest) ([]RSSFeedItem, error) {
 			if err == nil {
 				var link string
 
-				if item.Link[0] == '/' {
+				if len(item.Link) > 0 && item.Link[0] == '/' {
 					link = item.Link
 				} else {
 					link = "/" + item.Link


### PR DESCRIPTION
# Fix RSS item link empty


```
panic: runtime error: index out of range [0] with length 0

goroutine 40 [running]:
github.com/glanceapp/glance/internal/feed.getItemsFromRSSFeedTask({{0xc000121aa0, 0x2a}, {0x0, 0x0}, 0x1, 0x1, {0x0, 0x0}})
	/home/ccjjxl/data/dev/glance/internal/feed/rss.go:103 +0xaaf
github.com/glanceapp/glance/internal/feed.workerPoolDo[...].func1()
	/home/ccjjxl/data/dev/glance/internal/feed/requests.go:193 +0x14d
created by github.com/glanceapp/glance/internal/feed.workerPoolDo[...] in goroutine 24
	/home/ccjjxl/data/dev/glance/internal/feed/requests.go:189 +0xff
exit status 2

```
