### PR TITLE
feat: hide-title and show-domain-source for rss mainly for FreshRSS

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -518,9 +518,14 @@ An array of RSS/atom feeds. The title can optionally be changed.
 | hide-categories | boolean | no | false | Only applicable for `detailed-list` style |
 | hide-description | boolean | no | false | Only applicable for `detailed-list` style |
 | item-link-prefix | string | no | | |
+| hide-title | boolean | no | false | |
+| show-domain-source | boolean | no | false | |
 
 ###### `item-link-prefix`
 If an RSS feed isn't returning item links with a base domain and Glance has failed to automatically detect the correct domain you can manually add a prefix to each link with this property.
+
+###### `show-domain-source`
+Useful when using FreshRSS' user queries since it shows the query name instead of the actual source
 
 ##### `limit`
 The maximum number of articles to show.

--- a/internal/assets/static/main.css
+++ b/internal/assets/static/main.css
@@ -795,6 +795,11 @@ details[open] .summary::after {
     top: 0.1rem;
 }
 
+.list-horizontal-text > .rss-li {
+    display: inline-flex;
+    align-items: center;
+}
+
 .header-container {
     margin-top: calc(var(--widget-gap) / 2);
     --header-height: 45px;

--- a/internal/assets/templates/rss-detailed-list.html
+++ b/internal/assets/templates/rss-detailed-list.html
@@ -16,10 +16,17 @@
         <div class="grow min-width-0">
             <a class="size-h3 color-primary-if-not-visited" href="{{ .Link }}" target="_blank" rel="noreferrer">{{ .Title }}</a>
             <ul class="list-horizontal-text flex-nowrap">
-                <li {{ dynamicRelativeTimeAttrs .PublishedAt }}></li>
-                <li class="min-width-0">
+                <li class="rss-li" {{ dynamicRelativeTimeAttrs .PublishedAt }}></li>
+                {{ if .ChannelName }}
+                <li class="rss-li min-width-0">
                     <a class="block text-truncate" href="{{ .ChannelURL }}" target="_blank" rel="noreferrer">{{ .ChannelName }}</a>
                 </li>
+                {{ end }}
+                {{ if .SourceName }}
+                <li class="rss-li min-width-0">
+                    <a class="block text-truncate" href="{{ .SourceURL }}" target="_blank" rel="noreferrer">{{ .SourceName }}</a>
+                </li>
+                {{ end }}
             </ul>
             {{ if ne "" .Description }}
             <p class="rss-detailed-description text-truncate-2-lines margin-top-10">{{ .Description }}</p>

--- a/internal/assets/templates/rss-horizontal-cards-2.html
+++ b/internal/assets/templates/rss-horizontal-cards-2.html
@@ -19,7 +19,12 @@
                 <a href="{{ .Link }}" title="{{ .Title }}" class="block text-truncate color-primary-if-not-visited" target="_blank" rel="noreferrer">{{ .Title }}</a>
                 <ul class="list-horizontal-text flex-nowrap margin-top-5">
                     <li class="shrink-0" {{ dynamicRelativeTimeAttrs .PublishedAt }}></li>
+                    {{ if .ChannelName }}
                     <li class="min-width-0 text-truncate">{{ .ChannelName }}</li>
+                    {{ end }}
+                    {{ if .SourceName }}
+                    <li class="min-width-0 text-truncate">{{ .SourceName }}</li>
+                    {{ end }}
                 </ul>
             </div>
         </div>

--- a/internal/assets/templates/rss-horizontal-cards.html
+++ b/internal/assets/templates/rss-horizontal-cards.html
@@ -19,7 +19,12 @@
                 <a href="{{ .Link }}" title="{{ .Title }}" class="text-truncate-3-lines color-primary-if-not-visited margin-top-10 margin-bottom-auto" target="_blank" rel="noreferrer">{{ .Title }}</a>
                 <ul class="list-horizontal-text flex-nowrap margin-top-7">
                     <li class="shrink-0" {{ dynamicRelativeTimeAttrs .PublishedAt }}></li>
+                    {{ if .ChannelName }}
                     <li class="min-width-0 text-truncate">{{ .ChannelName }}</li>
+                    {{ end }}
+                    {{ if .SourceName }}
+                    <li class="min-width-0 text-truncate">{{ .SourceName }}</li>
+                    {{ end }}
                 </ul>
             </div>
         </div>

--- a/internal/assets/templates/rss-list.html
+++ b/internal/assets/templates/rss-list.html
@@ -6,10 +6,17 @@
     <li>
         <a class="title size-title-dynamic color-primary-if-not-visited" href="{{ .Link }}" target="_blank" rel="noreferrer" title="{{ .Title }}">{{ .Title }}</a>
         <ul class="list-horizontal-text flex-nowrap">
-            <li {{ dynamicRelativeTimeAttrs .PublishedAt }}></li>
-            <li class="min-width-0">
+            <li class="rss-li" {{ dynamicRelativeTimeAttrs .PublishedAt }}></li>
+            {{ if .ChannelName }}
+            <li class="rss-li min-width-0">
                 <a class="block text-truncate" href="{{ .ChannelURL }}" target="_blank" rel="noreferrer">{{ .ChannelName }}</a>
             </li>
+            {{ end }}
+            {{ if .SourceName }}
+            <li class="rss-li min-width-0">
+                <a class="block text-truncate" href="{{ .SourceURL }}" target="_blank" rel="noreferrer">{{ .SourceName }}</a>
+            </li>
+            {{ end }}
         </ul>
     </li>
     {{ else }}

--- a/internal/feed/rss.go
+++ b/internal/feed/rss.go
@@ -24,6 +24,8 @@ type RSSFeedItem struct {
 	Categories  []string
 	Description string
 	PublishedAt time.Time
+	SourceName  string
+	SourceURL   string
 }
 
 // doesn't cover all cases but works the vast majority of the time
@@ -63,6 +65,8 @@ type RSSFeedRequest struct {
 	HideDescription bool   `yaml:"hide-description"`
 	ItemLinkPrefix  string `yaml:"item-link-prefix"`
 	IsDetailed      bool   `yaml:"-"`
+	HideTitle       bool   `yaml:"hide-title"`
+	ShowSource      bool   `yaml:"show-domain-source"`
 }
 
 type RSSFeedItems []RSSFeedItem
@@ -150,7 +154,18 @@ func getItemsFromRSSFeedTask(request RSSFeedRequest) ([]RSSFeedItem, error) {
 			}
 		}
 
-		if request.Title != "" {
+		if request.ShowSource {
+			parsedUrl, err := url.Parse(rssItem.Link)
+			if err != nil {
+				return nil, err
+			}
+			rssItem.SourceName = parsedUrl.Host
+			rssItem.SourceURL = parsedUrl.Scheme + "://" + parsedUrl.Host
+		}
+
+		if request.HideTitle {
+			rssItem.ChannelName = ""
+		} else if request.Title != "" {
 			rssItem.ChannelName = request.Title
 		} else {
 			rssItem.ChannelName = feed.Title


### PR DESCRIPTION
<!--

If your pull request adds new features or changes existing ones please use the latest release/* branch as the base.

Documentation updates (including new themes) can be submitted to the main branch.

-->

This aims to add clarity as to where the feed source comes from. Mainly for FreshRSS [User queries](https://freshrss.github.io/FreshRSS/en/users/user_queries.html) where only the query name shows.

`show-domain-source`:

![sample_rss](https://github.com/user-attachments/assets/fb5bfb31-45ea-4f83-84e0-b1c632f6f667)

if paired with `hide-title`:

![image](https://github.com/user-attachments/assets/9bc816d6-5bdb-45d9-8489-5e4d571179f5)



<sub>Also, I noticed that the horizontal cards didn't have a link, so I also didn't add one for them</sub>

Please update anything that needs updating