### PR TITLE
feat: added title-line-limit for horizontal-cards style

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -465,15 +465,16 @@ Example:
 ```
 
 #### Properties
-| Name | Type | Required | Default |
-| ---- | ---- | -------- | ------- |
-| style | string | no | vertical-list |
-| feeds | array | yes |
-| thumbnail-height | float | no | 10 |
-| card-height | float | no | 27 |
-| limit | integer | no | 25 |
-| single-line-titles | boolean | no | false |
-| collapse-after | integer | no | 5 |
+| Name | Type | Required | Default | Note
+| ---- | ---- | -------- | ------- | ------- |
+| style | string | no | vertical-list | |
+| feeds | array | yes | |
+| thumbnail-height | float | no | 10 | |
+| card-height | float | no | 27 | |
+| limit | integer | no | 25 | |
+| single-line-titles | boolean | no | false | |
+| collapse-after | integer | no | 5 | |
+| title-line-limit | integer | no | 3 | Only applicable for `horizontal-cards` style. Max is 3 |
 
 ##### `style`
 Used to change the appearance of the widget. Possible values are:

--- a/internal/assets/templates/rss-horizontal-cards.html
+++ b/internal/assets/templates/rss-horizontal-cards.html
@@ -16,7 +16,8 @@
             </svg>
             {{ end }}
             <div class="margin-bottom-widget padding-inline-widget flex flex-column grow">
-                <a href="{{ .Link }}" title="{{ .Title }}" class="text-truncate-3-lines color-primary-if-not-visited margin-top-10 margin-bottom-auto" target="_blank" rel="noreferrer">{{ .Title }}</a>
+                <a href="{{ .Link }}" title="{{ .Title }}" 
+                    class="{{ if eq $.TitleLineLimit 1 }}text-truncate{{ else }}text-truncate-{{ $.TitleLineLimit }}-lines{{ end }} color-primary-if-not-visited margin-top-10 margin-bottom-auto" target="_blank" rel="noreferrer">{{ .Title }}</a>
                 <ul class="list-horizontal-text flex-nowrap margin-top-7">
                     <li class="shrink-0" {{ dynamicRelativeTimeAttrs .PublishedAt }}></li>
                     <li class="min-width-0 text-truncate">{{ .ChannelName }}</li>

--- a/internal/widget/rss.go
+++ b/internal/widget/rss.go
@@ -15,6 +15,7 @@ type RSS struct {
 	Style            string                `yaml:"style"`
 	ThumbnailHeight  float64               `yaml:"thumbnail-height"`
 	CardHeight       float64               `yaml:"card-height"`
+	TitleLineLimit   int                   `yaml:"title-line-limit"`
 	Items            feed.RSSFeedItems     `yaml:"-"`
 	Limit            int                   `yaml:"limit"`
 	CollapseAfter    int                   `yaml:"collapse-after"`
@@ -39,6 +40,10 @@ func (widget *RSS) Initialize() error {
 
 	if widget.CardHeight < 0 {
 		widget.CardHeight = 0
+	}
+
+	if widget.TitleLineLimit <= 0 || widget.TitleLineLimit > 3 {
+		widget.TitleLineLimit = 3
 	}
 
 	if widget.Style == "detailed-list" {


### PR DESCRIPTION
<!--

If your pull request adds new features or changes existing ones please use the latest release/* branch as the base.

Documentation updates (including new themes) can be submitted to the main branch.

-->

I have a Twitch RSS that displays like a YouTube videos, but usually twitch title can be 1 line and sometimes 3 lines, which can lead to awkward gap.

![vidfeed](https://github.com/user-attachments/assets/943048da-f72c-49a4-ad55-57ac976e59ef)

This will only add `title-line-limit` which uses the current css class for truncating texts
```yaml
   - type: rss
        title: Twitch
        style: horizontal-cards
        title-line-limit: 2
        feeds:
          - url: http://freshrss.local/api/query.php?user=user&t=token&f=rss
```
![image](https://github.com/user-attachments/assets/6e1ee2e1-4b08-49f0-a564-8d914f173430)
