### PR TITLE
DNS Stats widget - fix Pihole privacy edge case

### DIFF
--- a/internal/feed/pihole.go
+++ b/internal/feed/pihole.go
@@ -1,6 +1,7 @@
 package feed
 
 import (
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -9,24 +10,33 @@ import (
 )
 
 type piholeStatsResponse struct {
-	TotalQueries      int            `json:"dns_queries_today"`
-	QueriesSeries     map[int64]int  `json:"domains_over_time"`
-	BlockedQueries    int            `json:"ads_blocked_today"`
-	BlockedSeries     map[int64]int  `json:"ads_over_time"`
-	BlockedPercentage float64        `json:"ads_percentage_today"`
-	TopBlockedDomains map[string]int `json:"top_ads"`
-	DomainsBlocked    int            `json:"domains_being_blocked"`
+	TotalQueries      int                     `json:"dns_queries_today"`
+	QueriesSeries     map[int64]int           `json:"domains_over_time"`
+	BlockedQueries    int                     `json:"ads_blocked_today"`
+	BlockedSeries     map[int64]int           `json:"ads_over_time"`
+	BlockedPercentage float64                 `json:"ads_percentage_today"`
+	TopBlockedDomains piholeTopBlockedDomains `json:"top_ads"`
+	DomainsBlocked    int                     `json:"domains_being_blocked"`
 }
 
 // If user has some level of privacy enabled on Pihole, `json:"top_ads"` is an empty array
-// Use alternate struct without that field to avoid error when unmarshalling
-type piholeStatsResponsePrivate struct {
-	TotalQueries      int            `json:"dns_queries_today"`
-	QueriesSeries     map[int64]int  `json:"domains_over_time"`
-	BlockedQueries    int            `json:"ads_blocked_today"`
-	BlockedSeries     map[int64]int  `json:"ads_over_time"`
-	BlockedPercentage float64        `json:"ads_percentage_today"`
-	DomainsBlocked    int            `json:"domains_being_blocked"`
+// Use custom unmarshal behavior to avoid not getting the rest of the valid data when unmarshalling
+type piholeTopBlockedDomains map[string]int
+
+func (p *piholeTopBlockedDomains) UnmarshalJSON(data []byte) error {
+	// NOTE: do not change to piholeTopBlockedDomains type here or it will cause a stack overflow
+	// because of the UnmarshalJSON method getting called recursively
+	temp := make(map[string]int)
+
+	err := json.Unmarshal(data, &temp)
+
+	if err != nil {
+		*p = make(piholeTopBlockedDomains)
+	} else {
+		*p = temp
+	}
+
+	return nil
 }
 
 func FetchPiholeStats(instanceURL, token string) (*DNSStats, error) {
@@ -42,27 +52,13 @@ func FetchPiholeStats(instanceURL, token string) (*DNSStats, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	responseJson, err := decodeJsonFromRequest[piholeStatsResponse](defaultClient, request)
-	
+
 	if err != nil {
-		// Refer to piholeStatsResponsePrivate above
-		responseJsonPriv, err :=
-			decodeJsonFromRequest[piholeStatsResponsePrivate](defaultClient, request)
-		if err != nil {
-			return nil, err
-		}
-		
-		// Copy the results back to responseJson, leaving the TopBlockedDomains field empty
-		responseJson.TotalQueries = responseJsonPriv.TotalQueries
-		responseJson.QueriesSeries = responseJsonPriv.QueriesSeries
-		responseJson.BlockedQueries = responseJsonPriv.BlockedQueries
-		responseJson.BlockedSeries = responseJsonPriv.BlockedSeries
-		responseJson.BlockedPercentage = responseJsonPriv.BlockedPercentage
-		responseJson.TopBlockedDomains = make(map[string]int)
-		responseJson.DomainsBlocked = responseJsonPriv.DomainsBlocked
+		return nil, err
 	}
-	
+
 	stats := &DNSStats{
 		TotalQueries:   responseJson.TotalQueries,
 		BlockedQueries: responseJson.BlockedQueries,


### PR DESCRIPTION
There are privacy settings on the Pihole which affect the output of the API.
![pihole](https://github.com/user-attachments/assets/094f2dbe-2925-4279-95a3-596317afccc8)

When **any privacy settings other than "Show everything"** is selected on the Pihole, the DNS Stats widget fails with this error:

![widget_with_privacy](https://github.com/user-attachments/assets/10fff4a0-0d1a-4daf-b0e8-e6ec7e3a4d30)

The problem is that one of the fields (`top_ads`) in the JSON response from Pihole's API turns to an empty array because of the setting. For reference, with the privacy setting...
![with_privacy](https://github.com/user-attachments/assets/010b3952-722c-4a1b-8345-8f9ef72219bf)

... and without:
![without_privacy](https://github.com/user-attachments/assets/979f28bb-9f11-491f-93f9-35ca1fa225d5)

I made a fix in `pihole.go` -- it just uses an alternate struct definition that does not expect `top_ads` if the original one fails. It copies to the original struct instance to sidestep any type errors, though it does look a little ugly. Here's how it looks after the fix:
![after_fix](https://github.com/user-attachments/assets/a7323f3f-300f-4980-b795-e54be9a5014d)

It's my first time using Go, so I'm not sure if this was the best way to fix it. Do let me know if there's anything I can do to improve this.