### PR TITLE
Add Markets sort-by: change to sort by percent change

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1539,7 +1539,7 @@ Preview:
 An array of markets for which to display information about.
 
 ##### `sort-by`
-By default the markets are displayed in the order they were defined. You can customize their ordering by setting the `sort-by` property to `absolute-change` for descending order based on the stock's absolute price change.
+By default the markets are displayed in the order they were defined. You can customize their ordering by setting the `sort-by` property to `change` for descending order based on the stock's percentage change (e.g. 1% would be sorted higher than -1%) or `absolute-change` for descending order based on the stock's absolute price change (e.g. -1% would be sorted higher than +0.5%).
 
 ###### Properties for each stock
 | Name | Type | Required |

--- a/internal/feed/primitives.go
+++ b/internal/feed/primitives.go
@@ -133,6 +133,12 @@ func (t Markets) SortByAbsChange() {
 	})
 }
 
+func (t Markets) SortByChange() {
+	sort.Slice(t, func(i, j int) bool {
+		return t[i].PercentChange > t[j].PercentChange
+	})
+}
+
 var weatherCodeTable = map[int]string{
 	0:  "Clear Sky",
 	1:  "Mainly Clear",

--- a/internal/widget/markets.go
+++ b/internal/widget/markets.go
@@ -38,6 +38,10 @@ func (widget *Markets) Update(ctx context.Context) {
 		markets.SortByAbsChange()
 	}
 
+	if widget.Sort == "change" {
+		markets.SortByChange()
+	}
+
 	widget.Markets = markets
 }
 


### PR DESCRIPTION
Adding the option to sort markets by percent change (non-absolute value).  New config looks like:

```yaml
- type: markets
  sort-by: change
  markets:
    - symbol: AMZN
      name: Amazon
      symbol-link: https://finance.yahoo.com/quote/AMZN
    - symbol: NVDA
      name: NVIDIA
      symbol-link: https://finance.yahoo.com/quote/NVDA
    - symbol: ASML
      name: ASML
      symbol-link: https://finance.yahoo.com/quote/ASML
    - symbol: TSM
      name: TSMC
      symbol-link: https://finance.yahoo.com/quote/TSM
    - symbol: AMD
      name: AMD
      symbol-link: https://finance.yahoo.com/quote/AMD
    - symbol: ARM
      name: ARM
      symbol-link: https://finance.yahoo.com/quote/ARM
```

Example:
![image](https://github.com/user-attachments/assets/dc0576e4-3f66-4693-a1b4-825dfc6c25f5)
