### PR TITLE
fix: non-whole-hour timezones now correctly shown on Clock widget

### DIFF
--- a/internal/assets/static/js/main.js
+++ b/internal/assets/static/js/main.js
@@ -502,9 +502,24 @@ function timeInZone(now, zone) {
         timeInZone = now
     }
 
-    const diffInHours = Math.round((timeInZone.getTime() - now.getTime()) / 1000 / 60 / 60);
+    const diffInMinutes = Math.round((timeInZone.getTime() - now.getTime()) / 1000 / 60);
 
-    return { time: timeInZone, diffInHours: diffInHours };
+    return { time: timeInZone, diffInMinutes: diffInMinutes };
+}
+
+function zoneDiffText(diffInMinutes) {
+    if (diffInMinutes == 0) {
+        return "";
+    }
+
+    const sign = diffInMinutes < 0 ? "-" : "+";
+
+    diffInMinutes = Math.abs(diffInMinutes);
+    
+    const hours = `${Math.floor(diffInMinutes / 60)}`.padStart(2, '0');
+    const minutes = `${diffInMinutes % 60}`.padStart(2, '0');
+
+    return `${sign}${hours}:${minutes}`;
 }
 
 function setupClocks() {
@@ -547,9 +562,9 @@ function setupClocks() {
             );
 
             updateCallbacks.push((now) => {
-                const { time, diffInHours } = timeInZone(now, timeZoneContainer.dataset.timeInZone);
+                const { time, diffInMinutes } = timeInZone(now, timeZoneContainer.dataset.timeInZone);
                 setZoneTime(time);
-                diffElement.textContent = (diffInHours <= 0 ? diffInHours : '+' + diffInHours) + 'h';
+                diffElement.textContent = zoneDiffText(diffInMinutes);
             });
         }
     }

--- a/internal/assets/static/js/main.js
+++ b/internal/assets/static/js/main.js
@@ -513,13 +513,23 @@ function zoneDiffText(diffInMinutes) {
     }
 
     const sign = diffInMinutes < 0 ? "-" : "+";
+    const signText = diffInMinutes < 0 ? "behind" : "ahead";
 
     diffInMinutes = Math.abs(diffInMinutes);
-    
-    const hours = `${Math.floor(diffInMinutes / 60)}`.padStart(2, '0');
-    const minutes = `${diffInMinutes % 60}`.padStart(2, '0');
 
-    return `${sign}${hours}:${minutes}`;
+    const hours = Math.floor(diffInMinutes / 60);
+    const minutes = diffInMinutes % 60;
+    const hourSuffix = hours == 1 ? "" : "s";
+
+    if (minutes == 0) {
+        return { text: `${sign}${hours}h`, title: `${hours} hour${hourSuffix} ${signText}` };
+    }
+
+    if (hours == 0) {
+        return { text: `${sign}${minutes}m`, title: `${minutes} minutes ${signText}` };
+    }
+
+    return { text: `${sign}${hours}h~`, title: `${hours} hour${hourSuffix} and ${minutes} minutes ${signText}` };
 }
 
 function setupClocks() {
@@ -564,7 +574,9 @@ function setupClocks() {
             updateCallbacks.push((now) => {
                 const { time, diffInMinutes } = timeInZone(now, timeZoneContainer.dataset.timeInZone);
                 setZoneTime(time);
-                diffElement.textContent = zoneDiffText(diffInMinutes);
+                const { text, title } = zoneDiffText(diffInMinutes);
+                diffElement.textContent = text;
+                diffElement.title = title;
             });
         }
     }

--- a/internal/assets/static/main.css
+++ b/internal/assets/static/main.css
@@ -1339,6 +1339,10 @@ details[open] .summary::after {
     transform: translate(-50%, -50%);
 }
 
+.clock-time {
+    min-width: 8ch;
+}
+
 .clock-time span {
     color: var(--color-text-highlight);
 }


### PR DESCRIPTION
### Problem

Certain timezones use non-whole-hour definitions, for example, Australia/ACDT - which is GMT +10:30. Due to this, if either:
1. The user is in a whole-hour timezone (eg: CEST GMT+1), and they add a non-whole-hour timezone, or
2. The user is in a non-whole-hour timezone (eg: ACDT GMT+10:30), and they add a whole-hour timezone, 

then the relative difference between timezones is displayed within the Clock widget incorrectly, where the minutes are ignored, and only hourly differences being shown. Using the example of the user being in CEST, and requesting that ACDT be shown, only `+9h` will be displayed.

This is especially critical in timezones that relatively differ from each other by only 30 minutes, as the clock widget will show _no difference_ in timezones, represented as `0h` (for example, ACDT GMT+10:30 and AEDT GMT+11:00).

### Solution
This fix changes how the difference is calculated to account for both minutes, and hours.

Due to the change, the text shown for relative timezone differences also had to be changed, as the previous formatting was not appropriate for showing both minutes and hours. A similar format to the original was tested, which resulted in strings such as `+12h30m` or `+12h 30m`, both of which I deemed looked a bit strange. As such, I made a formatting change to instead use a standard `+-HH:MM` across the board (ie: `+12:30`).

<!--

If your pull request adds new features or changes existing ones please use the latest release/* branch as the base.

Documentation updates (including new themes) can be submitted to the main branch.

-->
