### PR TITLE
Add title prop to Market Name for full text of truncated names on hover

### DIFF
--- a/internal/assets/templates/markets.html
+++ b/internal/assets/templates/markets.html
@@ -6,7 +6,7 @@
     <div class="flex items-center gap-15">
         <div class="min-width-0">
             <a{{ if ne "" .SymbolLink }} href="{{ .SymbolLink }}" target="_blank" rel="noreferrer"{{ end }} class="color-highlight size-h3 block text-truncate">{{ .Symbol }}</a>
-            <div class="text-truncate">{{ .Name }}</div>
+            <div title="{{ .Name }}" class="text-truncate">{{ .Name }}</div>
         </div>
 
         <a class="market-chart" {{ if ne "" .ChartLink }} href="{{ .ChartLink }}" target="_blank" rel="noreferrer"{{ end }}>


### PR DESCRIPTION
Added a `title` param to the Markets Name `div` so that when longer names are used, and truncated, the full value can be seen on hover.
![market-name-hovertext](https://github.com/user-attachments/assets/2f34c185-7293-4352-807b-ec788e186ffa)
