### PR TITLE
Better autofocus, to make it work on mobile somehow

### DIFF
--- a/internal/assets/static/js/main.js
+++ b/internal/assets/static/js/main.js
@@ -614,6 +614,10 @@ async function setupPage() {
         setupLazyImages();
     } finally {
         pageElement.classList.add("content-ready");
+        const inputElement = document.getElementsByClassName("search-input")[0];
+		if (inputElement.dataset.autofocus == 'autofocus'){
+			inputElement.focus()
+		}
 
         for (let i = 0; i < contentReadyCallbacks.length; i++) {
             contentReadyCallbacks[i]();

--- a/internal/assets/templates/search.html
+++ b/internal/assets/templates/search.html
@@ -16,7 +16,7 @@
         </svg>
     </div>
 
-    <input class="search-input" type="text" placeholder="Type here to search…" autocomplete="off"{{ if .Autofocus }} autofocus{{ end }}>
+    <input class="search-input" type="text" placeholder="Type here to search…" autocomplete="off" data-autofocus="{{ if .Autofocus }}autofocus{{ end }}">
 
     <div class="search-bang"></div>
     <kbd class="hide-on-mobile" title="Press [S] to focus the search input">S</kbd>


### PR DESCRIPTION
## Whats the point
As mentioned in issue #208, `autofocus` attribute on search bar do not works on mobile devices. This is due to security restrictions of Android/IOS devices. Keyboard cant be toggled without any kind of user interaction. 
Here's what people from react-select who have encountered the same problem [say about it](https://github.com/JedWatson/react-select/issues/3501)

I don't think there is any workaround in this case, to make this functionality works.
But this PR, adding border animation on search bar to make them works like in desktop version. Without this change, user can`t even figure out, that autofocus flag is enabled, because borders are blurred.