### PR TITLE
Optionally start calendar weeks on Sunday

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1494,15 +1494,25 @@ Example:
 
 ```yaml
 - type: calendar
+  start-sunday: false
 ```
 
 Preview:
 
 ![](images/calendar-widget-preview.png)
 
+#### Properties
+
+| Name | Type | Required | Default |
+| ---- | ---- | -------- | ------- |
+| start-sunday | boolean | no | false |
+
+##### `start-sunday`
+Whether calendar weeks start on Sunday or Monday.
+
 > [!NOTE]
 >
-> There is currently no customizability available for the calendar. Extra features will be added in the future.
+> There is currently little customizability available for the calendar. Extra features will be added in the future.
 
 ### Markets
 Display a list of markets, their current value, change for the day and a small 21d chart. Data is taken from Yahoo Finance.

--- a/internal/assets/templates/calendar.html
+++ b/internal/assets/templates/calendar.html
@@ -11,13 +11,18 @@
     </div>
 
     <div class="flex flex-wrap size-h6 margin-top-10 color-subdue">
+        {{ if .StartSunday }}
+            <div class="calendar-day">Su</div>
+        {{ end }}
         <div class="calendar-day">Mo</div>
         <div class="calendar-day">Tu</div>
         <div class="calendar-day">We</div>
         <div class="calendar-day">Th</div>
         <div class="calendar-day">Fr</div>
         <div class="calendar-day">Sa</div>
-        <div class="calendar-day">Su</div>
+        {{ if not .StartSunday }}
+            <div class="calendar-day">Su</div>
+        {{ end }}
     </div>
 
     <div class="flex flex-wrap">

--- a/internal/feed/calendar.go
+++ b/internal/feed/calendar.go
@@ -7,9 +7,8 @@ import "time"
 func NewCalendar(now time.Time, startSunday bool) *Calendar {
 	year, week := now.ISOWeek()
 	weekday := now.Weekday()
-
-	if weekday == 0 {
-		weekday = 7
+	if !startSunday {
+		weekday = (weekday + 6) % 7 // Shift Monday to 0
 	}
 
 	currentMonthDays := daysInMonth(now.Month(), year)
@@ -22,11 +21,7 @@ func NewCalendar(now time.Time, startSunday bool) *Calendar {
 		previousMonthDays = daysInMonth(previousMonthNumber, year)
 	}
 
-	var offset time.Weekday = 6
-	if startSunday {
-		offset = 7
-	}
-	startDaysFrom := now.Day() - int(weekday+offset)
+	startDaysFrom := now.Day() - int(weekday) - 7
 
 	days := make([]int, 21)
 

--- a/internal/feed/calendar.go
+++ b/internal/feed/calendar.go
@@ -3,9 +3,8 @@ package feed
 import "time"
 
 // TODO: very inflexible, refactor to allow more customizability
-// TODO: allow changing first day of week
 // TODO: allow changing between showing the previous and next week and the entire month
-func NewCalendar(now time.Time) *Calendar {
+func NewCalendar(now time.Time, startSunday bool) *Calendar {
 	year, week := now.ISOWeek()
 	weekday := now.Weekday()
 
@@ -23,7 +22,11 @@ func NewCalendar(now time.Time) *Calendar {
 		previousMonthDays = daysInMonth(previousMonthNumber, year)
 	}
 
-	startDaysFrom := now.Day() - int(weekday+6)
+	var offset time.Weekday = 6
+	if startSunday {
+		offset = 7
+	}
+	startDaysFrom := now.Day() - int(weekday+offset)
 
 	days := make([]int, 21)
 

--- a/internal/widget/calendar.go
+++ b/internal/widget/calendar.go
@@ -10,8 +10,9 @@ import (
 )
 
 type Calendar struct {
-	widgetBase `yaml:",inline"`
-	Calendar   *feed.Calendar
+	widgetBase  `yaml:",inline"`
+	Calendar    *feed.Calendar
+	StartSunday bool `yaml:"start-sunday"`
 }
 
 func (widget *Calendar) Initialize() error {
@@ -21,7 +22,7 @@ func (widget *Calendar) Initialize() error {
 }
 
 func (widget *Calendar) Update(ctx context.Context) {
-	widget.Calendar = feed.NewCalendar(time.Now())
+	widget.Calendar = feed.NewCalendar(time.Now(), widget.StartSunday)
 	widget.withError(nil).scheduleNextUpdate()
 }
 


### PR DESCRIPTION
Allow the calendar widget to start on Sundays instead of Mondays using config.

#### start-sunday: false
![before](https://github.com/user-attachments/assets/f6f06a01-a6c2-4351-b9fc-ded9ecb0f9b1)

#### start-sunday: true
![after](https://github.com/user-attachments/assets/b9d7b774-1cea-4ea9-9560-8b7d50f1606e)


Sorry if base branch is wrong- I can rebase if needed, not sure what branch/tag?