### PR TITLE
Mobile style fixes

### DIFF
--- a/internal/glance/static/main.css
+++ b/internal/glance/static/main.css
@@ -1701,6 +1701,11 @@ details[open] .summary::after {
     .weather-column-rain::before {
         background-size: 7px 7px;
     }
+
+    .search-input {
+        /* so that iOS Safari does not zoom the page when the input is focused */
+        font-size: 16px;
+    }
 }
 
 @media (max-width: 1190px) and (display-mode: standalone) {
@@ -1717,7 +1722,8 @@ details[open] .summary::after {
         padding-bottom: var(--safe-area-inset-bottom);
     }
 
-    .mobile-navigation-icons {
+    .mobile-navigation-icons,
+    .content-bounds {
         padding-bottom: var(--safe-area-inset-bottom);
         transition: padding-bottom .3s;
     }
@@ -1799,6 +1805,7 @@ details[open] .summary::after {
 .min-width-0        { min-width: 0; }
 .max-width-100      { max-width: 100%; }
 .height-100         { height: 100%; }
+.height-100dvh      { height: 100dvh; }
 .block              { display: block; }
 .inline-block       { display: inline-block; }
 .overflow-hidden    { overflow: hidden; }

--- a/internal/glance/static/main.css
+++ b/internal/glance/static/main.css
@@ -330,7 +330,7 @@ html {
     scroll-behavior: smooth;
 }
 
-html, body {
+html, body, .body-content {
     height: 100%;
 }
 
@@ -1702,7 +1702,7 @@ details[open] .summary::after {
         background-size: 7px 7px;
     }
 
-    .search-input {
+    .ios .search-input {
         /* so that iOS Safari does not zoom the page when the input is focused */
         font-size: 16px;
     }
@@ -1713,7 +1713,11 @@ details[open] .summary::after {
         --safe-area-inset-bottom: env(safe-area-inset-bottom, 0);
     }
 
-    .list-collapsible-label:has(.list-collapsible-input:checked) {
+    .ios .body-content {
+        height: 100dvh;
+    }
+
+    .expand-toggle-button.container-expanded {
         bottom: calc(var(--mobile-navigation-height) + var(--safe-area-inset-bottom));
     }
 
@@ -1722,10 +1726,13 @@ details[open] .summary::after {
         padding-bottom: var(--safe-area-inset-bottom);
     }
 
-    .mobile-navigation-icons,
-    .content-bounds {
+    .mobile-navigation-icons {
         padding-bottom: var(--safe-area-inset-bottom);
         transition: padding-bottom .3s;
+    }
+
+    .mobile-navigation-offset {
+        height: calc(var(--mobile-navigation-height) + var(--safe-area-inset-bottom));
     }
 
     .mobile-navigation-icons:has(.mobile-navigation-page-links-input:checked) {
@@ -1804,8 +1811,6 @@ details[open] .summary::after {
 .shrink-0           { flex-shrink: 0; }
 .min-width-0        { min-width: 0; }
 .max-width-100      { max-width: 100%; }
-.height-100         { height: 100%; }
-.height-100dvh      { height: 100dvh; }
 .block              { display: block; }
 .inline-block       { display: inline-block; }
 .overflow-hidden    { overflow: hidden; }

--- a/internal/glance/templates/document.html
+++ b/internal/glance/templates/document.html
@@ -3,6 +3,7 @@
 <head>
     {{ block "document-head-before" . }}{{ end }}
     <title>{{ block "document-title" . }}{{ end }}</title>
+    <script>if (navigator.platform === 'iPhone') document.documentElement.classList.add('ios');</script>
     <meta charset="UTF-8">
     <meta name="color-scheme" content="dark">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">

--- a/internal/glance/templates/page.html
+++ b/internal/glance/templates/page.html
@@ -30,7 +30,7 @@
 {{ end }}
 
 {{ define "document-body" }}
-<div class="flex flex-column height-100dvh">
+<div class="flex flex-column body-content">
     {{ if not .Page.HideDesktopNavigation }}
     <div class="header-container content-bounds">
         <div class="header flex padding-inline-widget widget-content-frame">

--- a/internal/glance/templates/page.html
+++ b/internal/glance/templates/page.html
@@ -30,7 +30,7 @@
 {{ end }}
 
 {{ define "document-body" }}
-<div class="flex flex-column height-100">
+<div class="flex flex-column height-100dvh">
     {{ if not .Page.HideDesktopNavigation }}
     <div class="header-container content-bounds">
         <div class="header flex padding-inline-widget widget-content-frame">


### PR DESCRIPTION
This pull request aims to fix a few issues with styling on mobile devices.

1. `safe-area-inset-bottom` was used to add extra padding to the navigation bar to get it out of the way of the OS gesture bar, but no corresponding padding was present on the content. This meant that some of the content was blocked at the bottom by the nav bar when scrolled all the way down.
2. Tapping the search bar widget caused the page to zoom in on iOS. I changed the font-size to 16px, the minimum font size at which iOS will not zoom the page when focusing an input.
3. When there is not enough content on a dashboard to require scrolling, the mobile nav bar did not sit at the bottom of the page (see image below), so I changed the content height from `100%` to `100dvh` to fix this.

<img width="384" alt="Screenshot 2024-12-24 at 2 17 51 PM" src="https://github.com/user-attachments/assets/e2377ecf-7963-4dc6-9264-e8cd1b6e50c5" />
