### PR TITLE
feat: add possibility to set search input placeholder

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -871,6 +871,7 @@ Preview:
 | search-engine | string | no | duckduckgo |
 | new-tab | boolean | no | false |
 | autofocus | boolean | no | false |
+| placeholder | string | no | Type here to search… |
 | bangs | array | no | |
 
 ##### `search-engine`
@@ -886,6 +887,9 @@ When set to `true`, swaps the shortcuts for showing results in the same or new t
 
 ##### `autofocus`
 When set to `true`, automatically focuses the search input on page load.
+
+##### `placeholder`
+When set, modifies the text displayed in the input field before typing.
 
 ##### `bangs`
 What now? [Bangs](https://duckduckgo.com/bangs). They're shortcuts that allow you to use the same search box for many different sites. Assuming you have it configured, if for example you start your search input with `!yt` you'd be able to perform a search on YouTube:

--- a/internal/glance/templates/search.html
+++ b/internal/glance/templates/search.html
@@ -16,7 +16,7 @@
         </svg>
     </div>
 
-    <input class="search-input" type="text" placeholder="Type here to search…" autocomplete="off"{{ if .Autofocus }} autofocus{{ end }}>
+    <input class="search-input" type="text" placeholder="{{ .Placeholder }}" autocomplete="off"{{ if .Autofocus }} autofocus{{ end }}>
 
     <div class="search-bang"></div>
     <kbd class="hide-on-mobile" title="Press [S] to focus the search input">S</kbd>

--- a/internal/glance/widget-search.go
+++ b/internal/glance/widget-search.go
@@ -21,6 +21,7 @@ type searchWidget struct {
 	Bangs        []SearchBang  `yaml:"bangs"`
 	NewTab       bool          `yaml:"new-tab"`
 	Autofocus    bool          `yaml:"autofocus"`
+	Placeholder  string        `yaml:"placeholder"`
 }
 
 func convertSearchUrl(url string) string {
@@ -39,6 +40,10 @@ func (widget *searchWidget) initialize() error {
 
 	if widget.SearchEngine == "" {
 		widget.SearchEngine = "duckduckgo"
+	}
+
+	if widget.Placeholder == "" {
+		widget.Placeholder = "Type here to search…"
 	}
 
 	if url, ok := searchEngines[widget.SearchEngine]; ok {


### PR DESCRIPTION
Hello,

I've added the ability to edit the search input field placeholder.
For example, with the config below I have the result shown on the screenshot.

```yml
pages:
  - name: Startpage
    width: slim
    center-vertically: true
    columns:
      - size: full
        widgets:
          - type: search
            placeholder: type some text to search on internet…

theme:
  light: true
  background-color: 220 23 95
  contrast-multiplier: 1.0
  primary-color: 220 91 54
  positive-color: 109 58 40
  negative-color: 347 87 44
```
<img width="1103" alt="Capture d’écran 2025-01-03 à 19 34 18" src="https://github.com/user-attachments/assets/88f5a059-2457-46f8-b6a6-fc19a7bb4327" />

