### PR TITLE
docs for docker compose example fixed #179

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ services:
   glance:
     image: glanceapp/glance
     volumes:
+      - type: bind
+        source: ./glance.yml
+        target: /app/glance.yml
       - ./glance.yml:/app/glance.yml
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ services:
       - type: bind
         source: ./glance.yml
         target: /app/glance.yml
-      - ./glance.yml:/app/glance.yml
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     ports:


### PR DESCRIPTION
# Fix for docker compose glance.yml not mounting

This PR fixes the issue #179 which is caused because docker thinks glance.yml must be a directory and is therefore not recognizing the file.