### PR TITLE
feat: ChangeDetection-io Added support watch tags

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1420,6 +1420,7 @@ Preview:
 | limit | integer | no | 10 |
 | collapse-after | integer | no | 5 |
 | watches | array of strings | no |  |
+| tags | array of strings | no |  |
 
 ##### `instance-url`
 The URL pointing to your instance of `changedetection.io`.
@@ -1434,7 +1435,7 @@ The maximum number of watches to show.
 How many watches are visible before the "SHOW MORE" button appears. Set to `-1` to never collapse.
 
 ##### `watches`
-By default all of the configured watches will be shown. Optionally, you can specify a list of UUIDs for the specific watches you want to have listed:
+By default, when no tags nor watches are defined, all of the configured watches will be shown. Optionally, you can specify a list of UUIDs for the specific watches you want to have listed:
 
 ```yaml
   - type: change-detection
@@ -1442,6 +1443,10 @@ By default all of the configured watches will be shown. Optionally, you can spec
       - 1abca041-6d4f-4554-aa19-809147f538d3
       - 705ed3e4-ea86-4d25-a064-822a6425be2c
 ```
+
+##### `tags`
+A list of tags to be watched.
+
 
 ### Clock
 Display a clock showing the current time and date. Optionally, also display the the time in other timezones.

--- a/internal/feed/changedetection.go
+++ b/internal/feed/changedetection.go
@@ -35,11 +35,17 @@ type changeDetectionResponseJson struct {
 	PreviousHash string `json:"previous_md5"`
 }
 
-func FetchWatchUUIDsFromChangeDetection(instanceURL string, token string) ([]string, error) {
+func FetchWatchUUIDsFromChangeDetection(instanceURL string, token string, tag string) ([]string, error) {
 	request, _ := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/watch", instanceURL), nil)
 
 	if token != "" {
 		request.Header.Add("x-api-key", token)
+	}
+
+	if tag != "" {
+		query := request.URL.Query()
+		query.Add("tag", tag)
+		request.URL.RawQuery = query.Encode()
 	}
 
 	uuidsMap, err := decodeJsonFromRequest[map[string]struct{}](defaultClient, request)


### PR DESCRIPTION
Closes #310

Allows for specifying a list of tags that are used to populate the watch list e.g.

```yaml
- type: change-detection
  - tags:
    - gpu
    - rpi
```

This can be used in conjunction with the watches UUID list.

Results are filtered for duplicates.

This will not break existing configurations.

I've only tested with a local instance of change-detection as I don't have an account, but I don't see any reason why adding a query to the GET http request would behave differently.