### PR TITLE
feat: add alternate link (error-url) for monitor widget sites

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1220,6 +1220,7 @@ Properties for each site:
 | title | string | yes | |
 | url | string | yes | |
 | check-url | string | no | |
+| error-url | string | no | |
 | icon | string | no | |
 | allow-insecure | boolean | no | false |
 | same-tab | boolean | no | false |
@@ -1236,6 +1237,10 @@ The public facing URL of a monitored service, the user will be redirected here. 
 `check-url`
 
 The URL which will be requested and its response will determine the status of the site. If not specified, the `url` property is used.
+
+`error-url`
+
+If the monitored service returns an error, the user will be redirected here. If not specified, the `url` property is used.
 
 `icon`
 

--- a/internal/glance/templates/monitor.html
+++ b/internal/glance/templates/monitor.html
@@ -25,7 +25,11 @@
 <img class="monitor-site-icon{{ if .Icon.IsFlatIcon }} flat-icon{{ end }}" src="{{ .Icon.URL }}" alt="" loading="lazy">
 {{ end }}
 <div class="min-width-0">
+    {{ if and .Status.Error ( ne "" .ErrorURL)}}
+    <a class="size-h3 color-highlight text-truncate block" href="{{ .ErrorURL | safeURL }}" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer">{{ .Title }}</a>
+    {{ else }}
     <a class="size-h3 color-highlight text-truncate block" href="{{ .URL | safeURL }}" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer">{{ .Title }}</a>
+    {{ end }}
     <ul class="list-horizontal-text">
         {{ if not .Status.Error }}
         <li title="{{ .Status.Code }}">{{ .StatusText }}</li>

--- a/internal/glance/templates/monitor.html
+++ b/internal/glance/templates/monitor.html
@@ -25,11 +25,7 @@
 <img class="monitor-site-icon{{ if .Icon.IsFlatIcon }} flat-icon{{ end }}" src="{{ .Icon.URL }}" alt="" loading="lazy">
 {{ end }}
 <div class="min-width-0">
-    {{ if and .Status.Error ( ne "" .ErrorURL)}}
-    <a class="size-h3 color-highlight text-truncate block" href="{{ .ErrorURL | safeURL }}" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer">{{ .Title }}</a>
-    {{ else }}
     <a class="size-h3 color-highlight text-truncate block" href="{{ .URL | safeURL }}" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer">{{ .Title }}</a>
-    {{ end }}
     <ul class="list-horizontal-text">
         {{ if not .Status.Error }}
         <li title="{{ .Status.Code }}">{{ .StatusText }}</li>

--- a/internal/glance/widget-monitor.go
+++ b/internal/glance/widget-monitor.go
@@ -20,6 +20,7 @@ type monitorWidget struct {
 	Sites      []struct {
 		*SiteStatusRequest `yaml:",inline"`
 		Status             *siteStatus     `yaml:"-"`
+		URL                string          `yaml:"-"`
 		ErrorURL           string          `yaml:"error-url"`
 		Title              string          `yaml:"title"`
 		Icon               customIconField `yaml:"icon"`
@@ -59,8 +60,14 @@ func (widget *monitorWidget) update(ctx context.Context) {
 		status := &statuses[i]
 		site.Status = status
 
-		if !slices.Contains(site.AltStatusCodes, status.Code) && (status.Code >= 400 || status.TimedOut || status.Error != nil) {
+		if !slices.Contains(site.AltStatusCodes, status.Code) && (status.Code >= 400 || status.Error != nil) {
 			widget.HasFailing = true
+		}
+
+		if status.Error != nil && site.ErrorURL != "" {
+			site.URL = site.ErrorURL
+		} else {
+			site.URL = site.DefaultURL
 		}
 
 		site.StatusText = statusCodeToText(status.Code, site.AltStatusCodes)
@@ -89,11 +96,11 @@ func statusCodeToText(status int, altStatusCodes []int) string {
 	if status == 401 {
 		return "Unauthorized"
 	}
-	if status >= 400 {
-		return "Client Error"
-	}
 	if status >= 500 {
 		return "Server Error"
+	}
+	if status >= 400 {
+		return "Client Error"
 	}
 
 	return strconv.Itoa(status)
@@ -108,7 +115,7 @@ func statusCodeToStyle(status int, altStatusCodes []int) string {
 }
 
 type SiteStatusRequest struct {
-	URL           string `yaml:"url"`
+	DefaultURL    string `yaml:"url"`
 	CheckURL      string `yaml:"check-url"`
 	AllowInsecure bool   `yaml:"allow-insecure"`
 }
@@ -125,7 +132,7 @@ func fetchSiteStatusTask(statusRequest *SiteStatusRequest) (siteStatus, error) {
 	if statusRequest.CheckURL != "" {
 		url = statusRequest.CheckURL
 	} else {
-		url = statusRequest.URL
+		url = statusRequest.DefaultURL
 	}
 	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/internal/glance/widget-monitor.go
+++ b/internal/glance/widget-monitor.go
@@ -20,6 +20,7 @@ type monitorWidget struct {
 	Sites      []struct {
 		*SiteStatusRequest `yaml:",inline"`
 		Status             *siteStatus     `yaml:"-"`
+		ErrorURL           string          `yaml:"error-url"`
 		Title              string          `yaml:"title"`
 		Icon               customIconField `yaml:"icon"`
 		SameTab            bool            `yaml:"same-tab"`


### PR DESCRIPTION
This provides an optional parameter, error-url, per each site defined in a monitor widget. The parameter allows an alternate link to be returned when the site has an error (because the normal link by definition probably doesn't work).

For my usage, when a site returns an error it's most often because the docker is down or the site is misconfigured somehow; in either case I'd need to edit the configuration in my docker manager. So I have the error-url setup to point at a per site "http://docker-manager.local/specific-container" that's only available on my local network.