### PR TITLE
feat: add public-url parameter to rss widget feeds

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -532,11 +532,15 @@ An array of RSS/atom feeds. The title can optionally be changed.
 | Name | Type | Required | Default | Notes |
 | ---- | ---- | -------- | ------- | ----- |
 | url | string | yes | | |
+| public-url | string | no | | |
 | title | string | no | the title provided by the feed | |
 | hide-categories | boolean | no | false | Only applicable for `detailed-list` style |
 | hide-description | boolean | no | false | Only applicable for `detailed-list` style |
 | item-link-prefix | string | no | | |
 | headers | key (string) & value (string) | no | | |
+
+###### `public-url`
+An alternate url used when the RSS feed source is displayed as a clickable link.
 
 ###### `item-link-prefix`
 If an RSS feed isn't returning item links with a base domain and Glance has failed to automatically detect the correct domain you can manually add a prefix to each link with this property.

--- a/internal/glance/widget-rss.go
+++ b/internal/glance/widget-rss.go
@@ -140,6 +140,7 @@ func shortenFeedDescriptionLen(description string, maxLen int) string {
 
 type rssFeedRequest struct {
 	URL             string            `yaml:"url"`
+	PublicURL       string            `yaml:"public-url"`
 	Title           string            `yaml:"title"`
 	HideCategories  bool              `yaml:"hide-categories"`
 	HideDescription bool              `yaml:"hide-description"`
@@ -197,6 +198,10 @@ func fetchItemsFromRSSFeedTask(request rssFeedRequest) ([]rssFeedItem, error) {
 
 		rssItem := rssFeedItem{
 			ChannelURL: feed.Link,
+		}
+
+		if request.PublicURL != "" {
+			rssItem.ChannelURL = request.PublicURL
 		}
 
 		if request.ItemLinkPrefix != "" {


### PR DESCRIPTION
The rss feed widget shows a feed source which links directly to the feed url. You can find the link I'm referring to underneath each rss item's title, to the right of the "X hours ago" notice. Clicking that link in my browser downloads the rss.xml file, which is not preferred behavior. 

This provides an optional parameter `public-url` which can be set per feed to override this behavior.