### PR TITLE
Add authentication support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,7 @@
   - [Twitch Top Games](#twitch-top-games)
   - [iframe](#iframe)
   - [HTML](#html)
+  - [Authentication](#authentication)
 
 
 ## Preconfigured page
@@ -1254,7 +1255,6 @@ Examples:
       <div>
           <div class="color-highlight size-h3">{{ div (.JSON.Int "usage" | toFloat) 1073741824 | toInt | formatNumber }}GB</div>
           <div class="size-h6">USAGE</div>
-      </div>
     </div>
 ```
 </details>
@@ -1513,7 +1513,7 @@ Whether to ignore invalid/self-signed certificates.
 
 `same-tab`
 
-Whether to open the link in the same or a new tab.
+Whether to open the link in the same tab or a new one.
 
 `alt-status-codes`
 
@@ -2377,3 +2377,27 @@ Example:
 ```
 
 Note the use of `|` after `source:`, this allows you to insert a multi-line string.
+
+### Authentication
+Configure authentication for Glance using external services like Authelia or KeyCloak.
+
+Example:
+
+```yaml
+auth:
+  login-redirect-url: https://auth.example.com/login
+  is-authenticated-url: https://auth.example.com/is-authenticated
+```
+
+#### Properties
+
+| Name | Type | Required | Default |
+| ---- | ---- | -------- | ------- |
+| login-redirect-url | string | yes | |
+| is-authenticated-url | string | yes | |
+
+##### `login-redirect-url`
+The URL to redirect the user to when they need to log in.
+
+##### `is-authenticated-url`
+The URL to check if the user is authenticated.

--- a/internal/glance/config.go
+++ b/internal/glance/config.go
@@ -49,7 +49,19 @@ type config struct {
 		FaviconURL   string        `yaml:"favicon-url"`
 	} `yaml:"branding"`
 
+	Auth AuthConfig `yaml:"auth"`
+
 	Pages []page `yaml:"pages"`
+}
+
+type AuthConfig struct {
+	LoginRedirectURL    string `yaml:"login-redirect-url"`
+	IsAuthenticatedURL  string `yaml:"is-authenticated-url"`
+}
+
+type Auth interface {
+	IsAuthenticated(macAddress string) (bool, error)
+	JumpToLogin(macAddress string) error
 }
 
 type page struct {
@@ -325,6 +337,14 @@ func isConfigStateValid(config *config) error {
 		if _, err := os.Stat(config.Server.AssetsPath); os.IsNotExist(err) {
 			return fmt.Errorf("assets directory does not exist: %s", config.Server.AssetsPath)
 		}
+	}
+
+	if config.Auth.LoginRedirectURL == "" {
+		return fmt.Errorf("auth login-redirect-url is not configured")
+	}
+
+	if config.Auth.IsAuthenticatedURL == "" {
+		return fmt.Errorf("auth is-authenticated-url is not configured")
 	}
 
 	for i := range config.Pages {


### PR DESCRIPTION
Add authentication feature to Glance using external services.

* Add `AuthConfig` struct and `Auth` interface to `internal/glance/config.go`.
* Add `Auth` field to `config` struct and update `newConfigFromYAML` and `isConfigStateValid` functions.
* Add `auth` field to `application` struct in `internal/glance/glance.go`.
* Update `newApplication` function to initialize authentication instance.
* Update `handlePageRequest`, `handlePageContentRequest`, and `handleWidgetRequest` functions to check authentication.
* Update `serveApp` function in `internal/glance/main.go` to pass authentication configuration to `newApplication`.
* Add documentation for authentication configuration in `docs/configuration.md`.

