### PR TITLE
Auto-reload config file on RENAME

### DIFF
--- a/internal/glance/config.go
+++ b/internal/glance/config.go
@@ -286,6 +286,20 @@ func configFilesWatcher(
 				}
 				if event.Has(fsnotify.Write) {
 					debouncedCallback()
+				} else if event.Has(fsnotify.Rename) {
+					// wait for file to be available
+					for i := 0; i < 20; i++ {
+						_, err := os.Stat(mainFileAbsPath)
+						if err == nil {
+							break
+						}
+						time.Sleep(100 * time.Millisecond)
+					}
+					err := watcher.Add(mainFileAbsPath)
+					if err != nil {
+						onErr(fmt.Errorf("watching file:", err))
+					}
+					debouncedCallback()
 				} else if event.Has(fsnotify.Remove) {
 					func() {
 						mu.Lock()

--- a/internal/glance/config.go
+++ b/internal/glance/config.go
@@ -295,6 +295,9 @@ func configFilesWatcher(
 						}
 						time.Sleep(100 * time.Millisecond)
 					}
+					// fsnotify removes the file from the watch list on rename events,
+					// add it back.
+					// See https://github.com/fsnotify/fsnotify/issues/214
 					err := watcher.Add(mainFileAbsPath)
 					if err != nil {
 						onErr(fmt.Errorf("watching file:", err))


### PR DESCRIPTION
Some editors (like Vim), create a temp file when saving, then replace the file being edited with the temp file. This causes the FS notify event to be RENAME, not WRITE, so auto-reload misses this.

In addition to that, the file is removed from the watcher and the auto-reload functionality stops working entirely after the first RENAME.

https://github.com/fsnotify/fsnotify/issues/255 describes this.

<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->
