### PR TITLE
feat(monitor): add basic-auth feature for protected sites

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1476,6 +1476,7 @@ Properties for each site:
 | allow-insecure | boolean | no | false |
 | same-tab | boolean | no | false |
 | alt-status-codes | array | no | |
+| basic-auth | object | no | |
 
 `title`
 
@@ -1522,6 +1523,16 @@ Status codes other than 200 that you want to return "OK".
 ```yaml
 alt-status-codes:
   - 403
+```
+
+`basic-auth`
+
+HTTP Basic Authentication credentials for protected sites.
+
+```yaml
+basic-auth:
+  usename: your-username
+  password: your-password
 ```
 
 ### Releases

--- a/internal/glance/widget-monitor.go
+++ b/internal/glance/widget-monitor.go
@@ -28,10 +28,6 @@ type monitorWidget struct {
 		StatusText         string          `yaml:"-"`
 		StatusStyle        string          `yaml:"-"`
 		AltStatusCodes     []int           `yaml:"alt-status-codes"`
-		BasicAuth          struct {
-			Username string `yaml:"username"`
-			Password string `yaml:"password"`
-		} `yaml:"basic-auth"`
 	} `yaml:"sites"`
 	Style           string `yaml:"style"`
 	ShowFailingOnly bool   `yaml:"show-failing-only"`
@@ -49,10 +45,6 @@ func (widget *monitorWidget) update(ctx context.Context) {
 
 	for i := range widget.Sites {
 		requests[i] = widget.Sites[i].SiteStatusRequest
-		if widget.Sites[i].BasicAuth.Username != "" || widget.Sites[i].BasicAuth.Password != "" {
-			requests[i].Username = widget.Sites[i].BasicAuth.Username
-			requests[i].Password = widget.Sites[i].BasicAuth.Password
-		}
 	}
 
 	statuses, err := fetchStatusForSites(requests)
@@ -126,8 +118,10 @@ type SiteStatusRequest struct {
 	DefaultURL    string `yaml:"url"`
 	CheckURL      string `yaml:"check-url"`
 	AllowInsecure bool   `yaml:"allow-insecure"`
-	Username      string `yaml:"-"`
-	Password      string `yaml:"-"`
+	BasicAuth     struct {
+		Username string `yaml:"username"`
+		Password string `yaml:"password"`
+	} `yaml:"basic-auth"`
 }
 
 type siteStatus struct {
@@ -151,8 +145,8 @@ func fetchSiteStatusTask(statusRequest *SiteStatusRequest) (siteStatus, error) {
 		}, nil
 	}
 
-	if statusRequest.Username != "" || statusRequest.Password != "" {
-		request.SetBasicAuth(statusRequest.Username, statusRequest.Password)
+	if statusRequest.BasicAuth.Username != "" || statusRequest.BasicAuth.Password != "" {
+		request.SetBasicAuth(statusRequest.BasicAuth.Username, statusRequest.BasicAuth.Password)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)


### PR DESCRIPTION
this closes [issue #316](https://github.com/glanceapp/glance/issues/316)

This feature properly resolves sites that require basic auth credentials, so that it properly returns status `OK` instead of `Unauthorized`. 

At the very least, this can replace using `alt-status-codes` and adding `401` to it, which is like a "bogus" status `OK` (although if the intent is to just ping the site if its alive, then its good enough of a solution).
```yaml
- type: monitor
  cache: 1m
  title: Services
  sites:
    - title: Traefik
      url: https://traefik.example.com
      icon: di:traefik
      basic-auth:
        username: your-username
        password: your-password
```

Furthermore, this could be expanded to also pass the configured basic auth credentials to the request when the user clicks on the specific monitor widget.
