### PR TITLE
Correct document

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1608,7 +1608,7 @@ services:
   glance:
     image: glanceapp/glance
     environment:
-      - GITHUB_TOKEN: <your token>
+      - GITHUB_TOKEN=<your token>
 ```
 
 and then use it in your `glance.yml` like this:


### PR DESCRIPTION
Correct the docker compose environment format of GITHUB_TOKEN in the configuration document.

