### PR TITLE
feat: custom-api multiple API queries

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1319,7 +1319,7 @@ The template that will be used to display the data. It relies on Go's `html/temp
 A list of keys and values that will be sent to the custom-api as query paramters.
 
 ##### `subrequests`
-A map of additional requests that will be executed concurrently and then made available in the template via the `.Subrequests` property. Example:
+A map of additional requests that will be executed concurrently and then made available in the template via the `.Subrequest` property. Example:
 
 ```yaml
 - type: custom-api

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1290,11 +1290,34 @@ Examples:
 #### Properties
 | Name | Type | Required | Default |
 | ---- | ---- | -------- | ------- |
-| url | string | yes | |
+| url | string | yes, unless `api-queries` is set | |
 | headers | key (string) & value (string) | no | |
 | frameless | boolean | no | false |
 | template | string | yes | |
 | parameters | key & value | no | |
+| api-queries | list of urls, parameters & headers | no | |
+
+> [!NOTE]
+> 
+> `api-queries` will override `url`, `headers` and `parameters`
+> since it also provides its own options
+
+##### `api-queries`
+A list of API queries, the name set will be the name of the json returned
+```yaml
+api-queries:
+  sample-data1:
+    url: https://domain.com/api
+    parameters:
+      foo: bar
+    headers:
+      x-api-key: your-api-key
+      Accept: application/json
+  sample-data2:
+    url: https://another-domain.com/api
+```
+see [custom-api docs](./custom-api.md#api-queries)
+
 
 ##### `url`
 The URL to fetch the data from. It must be accessible from the server that Glance is running on.

--- a/docs/custom-api.md
+++ b/docs/custom-api.md
@@ -242,6 +242,28 @@ Other operations include `add`, `mul`, and `div`.
 
 <hr>
 
+#### API-Queries
+JSON response
+```json
+  {
+    "sample-data1": {
+      "title": "My Title",
+      "content": "My Content"
+    },
+    "sample-data2": [
+      {
+          "name": "John Doe"
+      },
+      {
+          "name": "Jane Doe"
+      }
+    ]
+  }
+```
+
+
+<hr>
+
 In some instances, you may want to know the status code of the response. This can be done using the following:
 
 ```html

--- a/docs/custom-api.md
+++ b/docs/custom-api.md
@@ -242,28 +242,6 @@ Other operations include `add`, `mul`, and `div`.
 
 <hr>
 
-#### API-Queries
-JSON response
-```json
-  {
-    "sample-data1": {
-      "title": "My Title",
-      "content": "My Content"
-    },
-    "sample-data2": [
-      {
-          "name": "John Doe"
-      },
-      {
-          "name": "Jane Doe"
-      }
-    ]
-  }
-```
-
-
-<hr>
-
 In some instances, you may want to know the status code of the response. This can be done using the following:
 
 ```html

--- a/internal/glance/widget-custom-api.go
+++ b/internal/glance/widget-custom-api.go
@@ -113,7 +113,6 @@ func fetchAndParseCustomAPI(requests map[string]*http.Request, tmpl *template.Te
 	var resp *http.Response
 	var err error
 	body := make(map[string]string)
-	mergedBody := "{}"
 	for key, req := range requests {
 		resp, err = defaultHTTPClient.Do(req)
 		if err != nil {
@@ -139,6 +138,7 @@ func fetchAndParseCustomAPI(requests map[string]*http.Request, tmpl *template.Te
 		}
 	}
 	
+	mergedBody := "{}"
 	if jsonBody, exists := body[customRandomKeyForSingleRequest]; exists {
 		mergedBody = jsonBody
 	} else {

--- a/internal/glance/widget-custom-api.go
+++ b/internal/glance/widget-custom-api.go
@@ -65,10 +65,6 @@ func (widget *customAPIWidget) initialize() error {
 		if widget.URL == "" {
 			return errors.New("URL is required")
 		}
-
-		if widget.Template == "" {
-			return errors.New("template is required")
-		}
 		
 		req, err := http.NewRequest(http.MethodGet, widget.URL, nil)
 		if err != nil {
@@ -82,6 +78,10 @@ func (widget *customAPIWidget) initialize() error {
 		}
 		
 		widget.APIRequest[customRandomKeyForSingleRequest] = req
+	}
+
+	if widget.Template == "" {
+		return errors.New("template is required")
 	}
 
 	compiledTemplate, err := template.New("").Funcs(customAPITemplateFuncs).Parse(widget.Template)

--- a/internal/glance/widget-custom-api.go
+++ b/internal/glance/widget-custom-api.go
@@ -199,11 +199,11 @@ func fetchAndParseCustomAPI(
 				var data *customAPIResponseData
 				data, localErr = fetchCustomAPIRequest(ctx, req)
 				mu.Lock()
-				if localErr != nil && err == nil {
+				if localErr == nil {
+					subData[key] = data
+				} else if err == nil {
 					err = localErr
 					cancel()
-				} else {
-					subData[key] = data
 				}
 				mu.Unlock()
 			}()


### PR DESCRIPTION
<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->
This is mainly to query multiple endpoints at once in the same `custom-api`, some services with API have the data you'd need, spread across multiple endpoints. Having only one kinda limits things so here we are.

You can also query different endpoints.

Sample config
```yaml
- type: custom-api
  define: <redacted>
  api-queries:
    yesterday:             # <--- This will become the object name where the api response gets stored
      url: http:${WEBSERVER_URL}/api/get-sonarr-data
      parameters:
        hour-offset: 8
        day-offset: -1
      <<: *sonarr-headers
    today:
      url: http:${WEBSERVER_URL}/api/get-sonarr-data
      parameters:
        hour-offset: 8
      <<: *sonarr-headers
    freshrss:
      url: http:${FRESHRSS_API}
      <<: 
        - *freshrss-parameters
        - *freshrss-headers
  cache: 1s
  template: |
    <div> - {{ .JSON.String "yesterday.data.0.airDate" }}</div>
    <div> - {{ .JSON.String "today.data.0.airDate" }}</div>
    <div> - {{ .JSON.String "freshrss.items.0.title" }}</div>
```

Output:
![Screenshot_20250303_010949](https://github.com/user-attachments/assets/32e2a395-a9b6-4d96-9993-9d7c2a60e9f8)
