### PR TITLE
feat: default-tab in group widget

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1035,6 +1035,11 @@ Preview:
 
 ![](images/group-widget-preview.png)
 
+#### Property
+| Name | Type | Required | Default |
+| ---- | ---- | -------- | ------- |
+| default-tab | int | no | 1 |
+
 #### Sharing properties
 
 To avoid repetition you can use [YAML anchors](https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/) and share properties between widgets.

--- a/internal/glance/static/js/main.js
+++ b/internal/glance/static/js/main.js
@@ -257,7 +257,7 @@ function setupGroups() {
         const group = groups[g];
         const titles = group.getElementsByClassName("widget-header")[0].children;
         const tabs = group.getElementsByClassName("widget-group-contents")[0].children;
-        let current = 0;
+        let current = Array.from(titles).findIndex(c => c.classList.contains('widget-group-title-current')) || 0;
 
         for (let t = 0; t < titles.length; t++) {
             const title = titles[t];

--- a/internal/glance/templates/group.html
+++ b/internal/glance/templates/group.html
@@ -6,14 +6,14 @@
 <div class="widget-group-header">
     <div class="widget-header gap-20">
         {{ range $i, $widget := .Widgets }}
-            <button class="widget-group-title{{ if eq $i 0 }} widget-group-title-current{{ end }}"{{ if ne "" .TitleURL }} data-title-url="{{ .TitleURL }}"{{ end }}>{{ $widget.Title }}</button>
+            <button class="widget-group-title{{ if eq $i $.DefaultTab }} widget-group-title-current{{ end }}"{{ if ne "" .TitleURL }} data-title-url="{{ .TitleURL }}"{{ end }}>{{ $widget.Title }}</button>
         {{ end }}
     </div>
 </div>
 
 <div class="widget-group-contents">
 {{ range $i, $widget := .Widgets }}
-    <div class="widget-group-content{{ if eq $i 0 }} widget-group-content-current{{ end }}">{{ .Render }}</div>
+    <div class="widget-group-content{{ if eq $i $.DefaultTab }} widget-group-content-current{{ end }}">{{ .Render }}</div>
 {{ end }}
 </div>
 

--- a/internal/glance/widget-group.go
+++ b/internal/glance/widget-group.go
@@ -12,11 +12,20 @@ var groupWidgetTemplate = mustParseTemplate("group.html", "widget-base.html")
 type groupWidget struct {
 	widgetBase          `yaml:",inline"`
 	containerWidgetBase `yaml:",inline"`
+	DefaultTab      int `yaml:"default-tab"`
 }
 
 func (widget *groupWidget) initialize() error {
 	widget.withError(nil)
 	widget.HideHeader = true
+
+	if widget.DefaultTab > 0 {
+		widget.DefaultTab = widget.DefaultTab - 1
+	}
+
+	if widget.DefaultTab > (len(widget.Widgets) - 1) {
+		widget.DefaultTab = len(widget.Widgets) - 1
+	}
 
 	for i := range widget.Widgets {
 		widget.Widgets[i].setHideHeader(true)


### PR DESCRIPTION
<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, 
otherwise use the main branch -->
```yaml
- type: group
  default-tab: 2 # <-- making tab 2 the default
  define1: &shared-properties
      allow-potentially-dangerous-html: true
      cache: 1s
  widgets:
    - type: extension
      title: Yesterday
      url: ${URL1}
      <<: *shared-properties
    - type: extension
      title: Sonarr Now
      url: ${URL2}
      <<: *shared-properties
    - type: extension
      title: Tomorrow
      url: ${URL3}
      <<: *shared-properties
```
