### PR TITLE
fix: full width clickable link for monitor-site

### DIFF
--- a/internal/glance/static/main.css
+++ b/internal/glance/static/main.css
@@ -2032,6 +2032,7 @@ details[open] .summary::after {
 .shrink-0           { flex-shrink: 0; }
 .min-width-0        { min-width: 0; }
 .max-width-100      { max-width: 100%; }
+.width-100          { width: 100% }
 .block              { display: block; }
 .inline-block       { display: inline-block; }
 .overflow-hidden    { overflow: hidden; }

--- a/internal/glance/static/main.css
+++ b/internal/glance/static/main.css
@@ -2032,7 +2032,6 @@ details[open] .summary::after {
 .shrink-0           { flex-shrink: 0; }
 .min-width-0        { min-width: 0; }
 .max-width-100      { max-width: 100%; }
-.width-100          { width: 100%; }
 .block              { display: block; }
 .inline-block       { display: inline-block; }
 .overflow-hidden    { overflow: hidden; }

--- a/internal/glance/static/main.css
+++ b/internal/glance/static/main.css
@@ -2032,7 +2032,7 @@ details[open] .summary::after {
 .shrink-0           { flex-shrink: 0; }
 .min-width-0        { min-width: 0; }
 .max-width-100      { max-width: 100%; }
-.width-100          { width: 100% }
+.width-100          { width: 100%; }
 .block              { display: block; }
 .inline-block       { display: inline-block; }
 .overflow-hidden    { overflow: hidden; }

--- a/internal/glance/templates/monitor.html
+++ b/internal/glance/templates/monitor.html
@@ -24,7 +24,7 @@
 {{ if .Icon.URL }}
 <img class="monitor-site-icon{{ if .Icon.IsFlatIcon }} flat-icon{{ end }}" src="{{ .Icon.URL }}" alt="" loading="lazy">
 {{ end }}
-<div class="min-width-0">
+<div class="width-100">
     <a class="size-h3 color-highlight text-truncate block" href="{{ .URL | safeURL }}" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer">{{ .Title }}</a>
     <ul class="list-horizontal-text">
         {{ if not .Status.Error }}

--- a/internal/glance/templates/monitor.html
+++ b/internal/glance/templates/monitor.html
@@ -24,7 +24,7 @@
 {{ if .Icon.URL }}
 <img class="monitor-site-icon{{ if .Icon.IsFlatIcon }} flat-icon{{ end }}" src="{{ .Icon.URL }}" alt="" loading="lazy">
 {{ end }}
-<div class="width-100">
+<div class="grow min-width-0">
     <a class="size-h3 color-highlight text-truncate block" href="{{ .URL | safeURL }}" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer">{{ .Title }}</a>
     <ul class="list-horizontal-text">
         {{ if not .Status.Error }}


### PR DESCRIPTION
<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->
I always find myself clicking a blank canvas next to the actual link, this just aims to expand the clickable area

The screenshot is just to show where the clickable part is.
Before:
![Screenshot_20250310_164158](https://github.com/user-attachments/assets/05539d97-0c7b-4b33-ac62-caafebc1e034)

After:
![Screenshot_20250310_164225](https://github.com/user-attachments/assets/a40b2d63-bcdf-483c-95b1-572570a02ffd)

This is more noticeable on mobile mode. Have to click across with just a right hand.