### PR TITLE
feat: last.fm widget

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,7 @@
   - [Twitch Top Games](#twitch-top-games)
   - [iframe](#iframe)
   - [HTML](#html)
+  - [Last.FM](#lastfm)
 
 
 ## Preconfigured page
@@ -2458,3 +2459,47 @@ Example:
 ```
 
 Note the use of `|` after `source:`, this allows you to insert a multi-line string.
+
+### Last.FM
+Displays your past and currently playing tracks
+
+Example:
+
+```yaml
+- type: last-fm
+  api-key: ${LAST_FM_API_KEY}
+  username: your_username
+```
+
+Preview:
+
+![](images/last-fm-widget-preview.gif)
+
+#### Properties
+
+| Name           | Type    | Required | Default |
+| -------------- | ------- | -------- | ------- |
+| api-key        | string  | yes      |         |
+| username       | string  | yes      |         |
+| limit          | integer | no       | 1       |
+| collapse-after | integer | no       | 1       |
+| square-cover   | boolean | no       | false   |
+| static-cover   | boolean | no       | false   |
+
+##### `api-key`
+Your Last.FM API key. Register [here](https://www.last.fm/api/authentication).
+
+##### `username`
+Your Last.FM username. You can find it in the URL of your profile. For example, `your_username` of `https://www.last.fm/user/your_username`.
+
+##### `limit`
+The maximum number of tracks to show.
+
+##### `collapse-after`
+How many tracks are visible before the "SHOW MORE" button appears. Set to `-1` to never collapse.
+
+##### `square-cover`
+When set to `true`, the album covers are square.
+
+##### `static-cover`
+When set to `true`, the track's album cover that is playing will not spin.

--- a/internal/glance/static/main.css
+++ b/internal/glance/static/main.css
@@ -1792,6 +1792,37 @@ details[open] .summary::after {
     background: linear-gradient(0deg, var(--color-widget-background) 10%, transparent);
 }
 
+.last-fm-album-cover-container {
+	width: 4.4rem;
+	height: 4.4rem;
+	border: 2px solid var(--color-text-subdue);
+	padding: 2px;
+	position: relative;
+	flex-shrink: 0;
+}
+
+.last-fm-first {
+	width: 6rem;
+	height: 6rem;
+}
+
+.last-fm-playing {
+	border-color: var(--color-positive);
+}
+
+.last-fm-spin {
+	animation: spin 20s infinite linear;
+}
+
+@keyframes spin {
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(360deg);
+	}
+}
+
 @media (max-width: 1190px) {
     .header-container {
         display: none;
@@ -2040,6 +2071,7 @@ details[open] .summary::after {
 .text-elevate       { margin-top: -0.2em; }
 .text-compact       { word-spacing: -0.18em; }
 .text-very-compact  { word-spacing: -0.35em; }
+.rounded-full       { border-radius: 100%; }
 .rtl                { direction: rtl; }
 .shrink             { flex-shrink: 1; }
 .shrink-0           { flex-shrink: 0; }

--- a/internal/glance/templates/last-fm.html
+++ b/internal/glance/templates/last-fm.html
@@ -1,0 +1,36 @@
+{{ template "widget-base.html" . }} {{ define "widget-content" }}
+<ul class="list list-gap-14 collapsible-container" data-collapse-after="{{ .CollapseAfter }}">
+	{{ range $index, $track := .Tracks }}
+	<li class="{{ if $track.IsPlaying }}last-fm-playing {{ end }} flex gap-10 thumbnail-parent">
+		<div
+			class="last-fm-album-cover-container
+      {{ if eq $index 0 }}last-fm-first {{ end }}
+      {{ if $track.IsPlaying }}last-fm-playing {{ end }}
+      {{ if not $.SquareCover }}rounded-full {{ end }}
+      {{ if and (not $.StaticCover) ($track.IsPlaying) }}last-fm-spin {{ end }}"
+		>
+			<a href="{{ $track.Url }}">
+				<img class="{{ if not $.SquareCover }}rounded-full {{ end }} thumbnail" style="aspect-ratio: 1" src="{{ $track.Image }}" alt="album cover" />
+			</a>
+		</div>
+
+		<div class="min-width-0">
+			<a class="text-truncate block {{ if $track.IsPlaying }}size-h3 color-primary {{ end }}" href="{{ $track.Url }}" target="_blank" rel="noreferrer"
+				>{{ $track.Song }}</a
+			>
+
+			<ul class="list-horizontal-text flex-nowrap">
+				{{ if not $track.IsPlaying }}
+				<li {{ dynamicRelativeTimeAttrs $track.PlayedAt }}></li>
+				{{ else }}
+				<li>Now</li>
+				{{ end }}
+				<li class="text-truncate">{{ $track.Artist }}</li>
+			</ul>
+		</div>
+	</li>
+	{{ else }}
+	<li>{{ $.NoItemsMessage }}</li>
+	{{ end }}
+</ul>
+{{ end }}

--- a/internal/glance/widget-last-fm.go
+++ b/internal/glance/widget-last-fm.go
@@ -1,0 +1,133 @@
+package glance
+
+import (
+	"context"
+	"fmt"
+	"html/template"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+var lastFmTemplate = mustParseTemplate("last-fm.html", "widget-base.html")
+
+type lastFmWidget struct {
+	widgetBase    `yaml:",inline"`
+	Tracks        lastFmTrackList `yaml:"-"`
+	ApiKey        string          `yaml:"api-key"`
+	Username      string          `yaml:"username"`
+	Limit         int             `yaml:"limit"`
+	CollapseAfter int             `yaml:"collapse-after"`
+	SquareCover   bool            `yaml:"square-cover"`
+	StaticCover   bool            `yaml:"static-cover"`
+}
+
+func (widget *lastFmWidget) initialize() error {
+	widget.
+		withTitle("Last.FM").
+		withTitleURL(fmt.Sprintf("https://www.last.fm/user/%s", widget.Username)).
+		withCacheDuration(1 * time.Minute)
+
+	if widget.Limit <= 0 {
+		widget.Limit = 1
+	}
+
+	if widget.CollapseAfter == 0 || widget.CollapseAfter < -1 {
+		widget.CollapseAfter = 1
+	}
+
+	return nil
+}
+
+func (widget *lastFmWidget) update(ctx context.Context) {
+	tracks, err := fetchLastFmRecentTracks(widget.ApiKey, widget.Username, widget.Limit)
+
+	if !widget.canContinueUpdateAfterHandlingErr(err) {
+		return
+	}
+
+	widget.Tracks = tracks
+}
+
+func (widget *lastFmWidget) Render() template.HTML {
+	return widget.renderTemplate(widget, lastFmTemplate)
+}
+
+type lastFmResponseJson struct {
+	RecentTracks struct {
+		TrackList []struct {
+			Artist struct {
+				Text string `json:"#text"`
+			} `json:"artist"`
+			Name  string `json:"name"`
+			Image []struct {
+				Text string `json:"#text"`
+			} `json:"image"`
+			Url        string `json:"url"`
+			Attributes *struct {
+				NowPlaying string `json:"nowplaying"`
+			} `json:"@attr"`
+			Date *struct {
+				Timestamp string `json:"uts"`
+			} `json:"date"`
+		} `json:"track"`
+	} `json:"recenttracks"`
+}
+
+type lastFmTrack struct {
+	Song      string
+	Artist    string
+	Image     string
+	Url       string
+	IsPlaying bool
+	PlayedAt  time.Time
+}
+
+type lastFmTrackList []lastFmTrack
+
+func fetchLastFmRecentTracks(apiKey string, username string, limit int) (lastFmTrackList, error) {
+	// The limit is increased by one to account for the currently playing song
+	url := fmt.Sprintf("http://ws.audioscrobbler.com/2.0/?method=user.getrecenttracks&user=%s&api_key=%s&format=json&limit=%d", username, apiKey, limit+1)
+
+	request, _ := http.NewRequest("GET", url, nil)
+	response, err := decodeJsonFromRequest[lastFmResponseJson](defaultHTTPClient, request)
+	if err != nil {
+		return nil, fmt.Errorf("%w: could not fetch recent last.fm tracks", errNoContent)
+	}
+
+	tracks := make(lastFmTrackList, 0, limit)
+
+	for _, lastFmData := range response.RecentTracks.TrackList {
+		var playedAt time.Time
+		if lastFmData.Date != nil {
+			// Convert string unix time to number
+			timestamp, err := strconv.Atoi(lastFmData.Date.Timestamp)
+			if err != nil {
+				return nil, fmt.Errorf("%w: could not convert timestamp to number", errNoContent)
+			}
+
+			playedAt = time.Unix(int64(timestamp), 0)
+		}
+
+		tracks = append(tracks, lastFmTrack{
+			Song:      lastFmData.Name,
+			Artist:    lastFmData.Artist.Text,
+			Image:     lastFmData.Image[1].Text,
+			Url:       lastFmData.Url,
+			IsPlaying: lastFmData.Attributes != nil,
+			PlayedAt:  playedAt,
+		})
+	}
+
+	// If no song is playing, remove the last track from the list
+	// See above for context (url variable)
+	if len(tracks) > limit && !tracks[len(tracks)-1].IsPlaying {
+		tracks = tracks[:limit]
+	}
+
+	if len(tracks) == 0 {
+		return nil, errNoContent
+	}
+
+	return tracks, nil
+}

--- a/internal/glance/widget.go
+++ b/internal/glance/widget.go
@@ -79,6 +79,8 @@ func newWidget(widgetType string) (widget, error) {
 		w = &dockerContainersWidget{}
 	case "server-stats":
 		w = &serverStatsWidget{}
+	case "last-fm":
+		w = &lastFmWidget{}
 	default:
 		return nil, fmt.Errorf("unknown widget type: %s", widgetType)
 	}


### PR DESCRIPTION
Adds a Last.FM widget which shows past and currently playing tracks from the user's profile.

#418 

![widget preview](https://github.com/user-attachments/assets/26ca582b-d5d3-4c50-8897-cb4d12142263)
