### PR TITLE
feat: automatic favicons

### DIFF
--- a/internal/glance/config.go
+++ b/internal/glance/config.go
@@ -23,6 +23,7 @@ type config struct {
 		Port       uint16    `yaml:"port"`
 		AssetsPath string    `yaml:"assets-path"`
 		BaseURL    string    `yaml:"base-url"`
+		CachePath  string    `yaml:"cache-path"`
 		StartedAt  time.Time `yaml:"-"` // used in custom css file
 	} `yaml:"server"`
 

--- a/internal/glance/favicon-cache.go
+++ b/internal/glance/favicon-cache.go
@@ -1,0 +1,112 @@
+package glance
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	faviconCacheDir      = "favicons"
+	faviconCacheDuration = 7 * 24 * time.Hour // 1 week cache
+	faviconServiceURL    = "https://www.google.com/s2/favicons?domain="
+)
+
+// getFaviconCachePath returns the path to the favicon cache directory
+func (a *application) getFaviconCachePath() string {
+	return filepath.Join(a.Config.Server.CachePath, faviconCacheDir)
+}
+
+// getFaviconPath returns the cached favicon path for a domain
+func (a *application) getFaviconPath(domain string) string {
+	// Create an MD5 hash of the domain to use as filename
+	hash := md5.Sum([]byte(domain))
+	filename := hex.EncodeToString(hash[:]) + ".ico"
+	return filepath.Join(a.getFaviconCachePath(), filename)
+}
+
+// ensureCacheDirExists ensures the favicon cache directory exists
+func (a *application) ensureCacheDirExists() error {
+	cacheDir := a.getFaviconCachePath()
+	if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
+		return os.MkdirAll(cacheDir, 0755)
+	}
+	return nil
+}
+
+// handleFaviconRequest handles requests for favicons, using local cache when available
+func (a *application) handleFaviconRequest(w http.ResponseWriter, r *http.Request) {
+	domain := r.URL.Query().Get("domain")
+	if domain == "" {
+		http.Error(w, "domain parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	// Ensure cache directory exists
+	if err := a.ensureCacheDirExists(); err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	faviconPath := a.getFaviconPath(domain)
+	
+	    // Check if favicon exists in cache and is fresh
+	    var cacheExists bool
+	    if info, err := os.Stat(faviconPath); err == nil {
+	        cacheExists = true
+	        if time.Since(info.ModTime()) < faviconCacheDuration {
+	            // Serve from cache if fresh
+	            http.ServeFile(w, r, faviconPath)
+	            return
+	        }
+	    }
+
+	// Favicon not in cache or is expired, fetch from Google
+	resp, err := http.Get(faviconServiceURL + domain)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		// If fetch fails but we have a cached version, refresh its timestamp and use it
+		if cacheExists {
+			// Update modification time to extend cache lifetime
+			now := time.Now()
+			os.Chtimes(faviconPath, now, now)
+			
+			// Serve stale cached favicon
+			http.ServeFile(w, r, faviconPath)
+			return
+		}
+		
+		// No cached version available, return error
+		http.Error(w, "Failed to fetch favicon", http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Create the cache file
+	f, err := os.Create(faviconPath)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	defer f.Close()
+
+	// Set content-type header if available
+	if contentType := resp.Header.Get("Content-Type"); contentType != "" {
+	    w.Header().Set("Content-Type", contentType)
+	} else {
+	    w.Header().Set("Content-Type", "image/x-icon")
+	}
+
+	// Set cache-control header
+	w.Header().Set("Cache-Control", "public, max-age=604800") // 1 week
+
+	// Write to cache file and response writer
+	mw := io.MultiWriter(f, w)
+	if _, err := io.Copy(mw, resp.Body); err != nil {
+	    http.Error(w, "Internal server error", http.StatusInternalServerError)
+	    return
+	}
+}

--- a/internal/glance/glance.go
+++ b/internal/glance/glance.go
@@ -227,6 +227,9 @@ func (a *application) server() (func() error, func() error) {
 	mux.HandleFunc("GET /api/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
+	
+	// Favicon proxy endpoint
+	mux.HandleFunc("GET /api/favicon", a.handleFaviconRequest)
 
 	mux.Handle(
 		fmt.Sprintf("GET /static/%s/{path...}", staticFSHash),

--- a/internal/glance/widget-bookmarks.go
+++ b/internal/glance/widget-bookmarks.go
@@ -2,6 +2,7 @@ package glance
 
 import (
 	"html/template"
+	"net/url"
 )
 
 var bookmarksWidgetTemplate = mustParseTemplate("bookmarks.html", "widget-base.html")
@@ -61,6 +62,14 @@ func (widget *bookmarksWidget) initialize() error {
 					} else {
 						link.Target = "_blank"
 					}
+					}
+				}
+			
+			if link.Icon.URL == "favicon" && link.URL != "" {
+				parsedURL, err := url.Parse(link.URL)
+				if err == nil {
+					// set the favicon proxy url directly on the URL field
+					link.Icon.URL = "/api/favicon?sz=32&domain=" + parsedURL.Hostname()
 				}
 			}
 		}


### PR DESCRIPTION
Hi,

I like favicons in my bookmarks. Easiest way to accomplish this is to add images straight from the google favicon api, but this would make new requests every 30mins, which seems unkind.

This is a slightly over-engineered proxy implementation that fetches favicons for the user and caches icons locally. Works by setting `icon: favicon` to a bookmark link. Not highly polished, yet. Let me know what you think.

Things of note:
- Includes a hard-coded cache of 1 week. Perhaps it would be better to cache forever and discard on restart, or at least add a setting.
- Could also/alternatively use favicone.com or duckduckgo's favicons.

## Example

```
        - type: bookmarks
          groups:
            - links:
                - title: Amazon
                  url: https://www.amazon.com/
                  icon: favicon
                - title: Github
                  url: https://github.com/
                  icon: favicon
                - title: Wikipedia
                  url: https://en.wikipedia.org/
                  icon: favicon
```

<img width="169" alt="image" src="https://github.com/user-attachments/assets/c1228c7c-a5d9-4f21-9148-bc5ed60f2af2" />
