### PR TITLE
[RFC] Expose serveApp so we can embed Glance

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,59 +264,31 @@ Glance can also be installed through the following 3rd party channels:
 
 <br>
 
-## Building from source
-
-Choose one of the following methods:
-
+## Common issues
 <details>
-<summary><strong>Build binary with Go</strong></summary>
-<br>
+<summary><strong>Requests timing out</strong></summary>
 
-Requirements: [Go](https://go.dev/dl/) >= v1.23
+The most common cause of this is when using Pi-Hole, AdGuard Home or other ad-blocking DNS services, which by default have a fairly low rate limit. Depending on the number of widgets you have in a single page, this limit can very easily be exceeded. To fix this, increase the rate limit in the settings of your DNS service.
 
-To build the project for your current OS and architecture, run:
-
-```bash
-go build -o build/glance .
+If using Podman, in some rare cases the timeout can be caused by an unknown issue, in which case it may be resolved by adding the following to the bottom of your `docker-compose.yml` file:
+```yaml
+networks:
+  podman:
+    external: true
 ```
-
-To build for a specific OS and architecture, run:
-
-```bash
-GOOS=linux GOARCH=amd64 go build -o build/glance .
-```
-
-[*click here for a full list of GOOS and GOARCH combinations*](https://go.dev/doc/install/source#:~:text=$GOOS%20and%20$GOARCH)
-
-Alternatively, if you just want to run the app without creating a binary, like when you're testing out changes, you can run:
-
-```bash
-go run .
-```
-<hr>
 </details>
 
 <details>
-<summary><strong>Build project and Docker image with Docker</strong></summary>
-<br>
+<summary><strong>Broken layout for markets, bookmarks or other widgets</strong></summary>
 
-Requirements: [Docker](https://docs.docker.com/engine/install/)
+This is almost always caused by the browser extension Dark Reader. To fix this, disable dark mode for the domain where Glance is hosted.
+</details>
 
-To build the project and image using just Docker, run:
+<details>
+<summary><strong>cannot unmarshal !!map into []glance.page</strong></summary>
 
-*(replace `owner` with your name or organization)*
+The most common cause of this is having a `pages` key in your `glance.yml` and then also having a `pages` key inside one of your included pages. To fix this, remove the `pages` key from the top of your included pages.
 
-```bash
-docker build -t owner/glance:latest .
-```
-
-If you wish to push the image to a registry (by default Docker Hub), run:
-
-```bash
-docker push owner/glance:latest
-```
-
-<hr>
 </details>
 
 <br>
@@ -372,6 +344,63 @@ Feature requests are tagged with one of the following:
 * [Roadmap](https://github.com/glanceapp/glance/labels/roadmap) - will be implemented in a future release
 * [Backlog](https://github.com/glanceapp/glance/labels/backlog) - may be implemented in the future but needs further feedback or interest from the community
 * [Icebox](https://github.com/glanceapp/glance/labels/icebox) - no plans to implement as it doesn't currently align with the project's goals or capabilities, may be revised at a later date
+
+<br>
+
+## Building from source
+
+Choose one of the following methods:
+
+<details>
+<summary><strong>Build binary with Go</strong></summary>
+<br>
+
+Requirements: [Go](https://go.dev/dl/) >= v1.23
+
+To build the project for your current OS and architecture, run:
+
+```bash
+go build -o build/glance .
+```
+
+To build for a specific OS and architecture, run:
+
+```bash
+GOOS=linux GOARCH=amd64 go build -o build/glance .
+```
+
+[*click here for a full list of GOOS and GOARCH combinations*](https://go.dev/doc/install/source#:~:text=$GOOS%20and%20$GOARCH)
+
+Alternatively, if you just want to run the app without creating a binary, like when you're testing out changes, you can run:
+
+```bash
+go run .
+```
+<hr>
+</details>
+
+<details>
+<summary><strong>Build project and Docker image with Docker</strong></summary>
+<br>
+
+Requirements: [Docker](https://docs.docker.com/engine/install/)
+
+To build the project and image using just Docker, run:
+
+*(replace `owner` with your name or organization)*
+
+```bash
+docker build -t owner/glance:latest .
+```
+
+If you wish to push the image to a registry (by default Docker Hub), run:
+
+```bash
+docker push owner/glance:latest
+```
+
+<hr>
+</details>
 
 <br>
 

--- a/internal/glance/diagnose.go
+++ b/internal/glance/diagnose.go
@@ -103,7 +103,7 @@ func runDiagnostic() {
 	fmt.Println("Glance version: " + buildVersion)
 	fmt.Println("Go version: " + runtime.Version())
 	fmt.Printf("Platform: %s / %s / %d CPUs\n", runtime.GOOS, runtime.GOARCH, runtime.NumCPU())
-	fmt.Println("In Docker container: " + boolToString(isRunningInsideDockerContainer(), "yes", "no"))
+	fmt.Println("In Docker container: " + ternary(isRunningInsideDockerContainer(), "yes", "no"))
 
 	fmt.Printf("\nChecking network connectivity, this may take up to %d seconds...\n\n", int(httpTestRequestTimeout.Seconds()))
 
@@ -129,7 +129,7 @@ func runDiagnostic() {
 
 		fmt.Printf(
 			"%s %s %s| %dms\n",
-			boolToString(step.err == nil, "✓ Can", "✗ Can't"),
+			ternary(step.err == nil, "✓ Can", "✗ Can't"),
 			step.name,
 			extraInfo,
 			step.elapsed.Milliseconds(),

--- a/internal/glance/main.go
+++ b/internal/glance/main.go
@@ -24,7 +24,7 @@ func Main() int {
 			return 1
 		}
 
-		if err := serveApp(options.configPath); err != nil {
+		if err := ServeApp(options.configPath); err != nil {
 			fmt.Println(err)
 			return 1
 		}
@@ -54,7 +54,7 @@ func Main() int {
 	return 0
 }
 
-func serveApp(configPath string) error {
+func ServeApp(configPath string) error {
 	exitChannel := make(chan struct{})
 	hadValidConfigOnStartup := false
 	var stopServer func() error

--- a/internal/glance/static/main.css
+++ b/internal/glance/static/main.css
@@ -552,6 +552,10 @@ kbd:active {
     z-index: 1;
 }
 
+.summary::-webkit-details-marker {
+    display: none;
+}
+
 .details[open] .summary {
     margin-bottom: .8rem;
 }

--- a/internal/glance/static/main.css
+++ b/internal/glance/static/main.css
@@ -1132,7 +1132,7 @@ details[open] .summary::after {
 
 .calendar-date {
     padding: 0.4rem 0;
-    color: var(--color-text-paragraph);
+    color: var(--color-text-base);
     position: relative;
     border-radius: var(--border-radius);
     background: none;

--- a/internal/glance/templates/docker-containers.html
+++ b/internal/glance/templates/docker-containers.html
@@ -1,10 +1,10 @@
 {{ template "widget-base.html" . }}
 
 {{- define "widget-content" }}
-<div class="dynamic-columns list-gap-20 list-with-separator">
+<ul class="dynamic-columns list-gap-20 list-with-separator">
     {{- range .Containers }}
-    <div class="docker-container flex items-center gap-15">
-        <div class="shrink-0" data-popover-type="html" data-popover-position="above" data-popover-offset="0.25" data-popover-margin="0.1rem" data-popover-max-width="400px">
+    <li class="docker-container flex items-center gap-15">
+        <div class="shrink-0" data-popover-type="html" data-popover-position="above" data-popover-offset="0.25" data-popover-margin="0.1rem" data-popover-max-width="400px" aria-hidden="true">
             <img class="docker-container-icon{{ if .Icon.IsFlatIcon }} flat-icon{{ end }}" src="{{ .Icon.URL }}" alt="" loading="lazy">
             <div data-popover-html>
                 <div class="color-highlight text-truncate block">{{ .Image }}</div>
@@ -33,31 +33,33 @@
             {{- end }}
         </div>
 
-        <div class="margin-left-auto shrink-0" data-popover-type="text" data-popover-position="above" data-popover-text="{{ .State }}">
+        <div class="margin-left-auto shrink-0" data-popover-type="text" data-popover-position="above" data-popover-text="{{ .State }}" aria-label="{{ .State }}">
         {{ template "state-icon" .StateIcon }}
         </div>
-    </div>
+
+        <div class="visually-hidden" aria-label="{{ .StateText }}"></div>
+    </li>
     {{- else }}
     <div class="text-center">No containers available to show.</div>
     {{- end }}
-</div>
+</ul>
 {{- end }}
 
 {{- define "state-icon" }}
 {{- if eq . "ok" }}
-<svg class="docker-container-status-icon" fill="var(--color-positive)" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+<svg class="docker-container-status-icon" fill="var(--color-positive)" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true">
     <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" />
 </svg>
 {{- else if eq . "warn" }}
-<svg class="docker-container-status-icon" fill="var(--color-negative)" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+<svg class="docker-container-status-icon" fill="var(--color-negative)" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true">
     <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 5Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clip-rule="evenodd" />
 </svg>
 {{- else if eq . "paused" }}
-<svg class="docker-container-status-icon" fill="var(--color-text-base)" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+<svg class="docker-container-status-icon" fill="var(--color-text-base)" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true">
     <path fill-rule="evenodd" d="M2 10a8 8 0 1 1 16 0 8 8 0 0 1-16 0Zm5-2.25A.75.75 0 0 1 7.75 7h.5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-.75.75h-.5a.75.75 0 0 1-.75-.75v-4.5Zm4 0a.75.75 0 0 1 .75-.75h.5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-.75.75h-.5a.75.75 0 0 1-.75-.75v-4.5Z" clip-rule="evenodd" />
 </svg>
 {{- else }}
-<svg class="docker-container-status-icon" fill="var(--color-text-base)" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+<svg class="docker-container-status-icon" fill="var(--color-text-base)" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true">
     <path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0ZM8.94 6.94a.75.75 0 1 1-1.061-1.061 3 3 0 1 1 2.871 5.026v.345a.75.75 0 0 1-1.5 0v-.5c0-.72.57-1.172 1.081-1.287A1.5 1.5 0 1 0 8.94 6.94ZM10 15a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clip-rule="evenodd" />
 </svg>
 {{- end }}

--- a/internal/glance/templates/videos-vertical-list.html
+++ b/internal/glance/templates/videos-vertical-list.html
@@ -6,7 +6,7 @@
     <li class="flex thumbnail-parent gap-10 items-center">
         <img class="video-horizontal-list-thumbnail thumbnail" loading="lazy" src="{{ .ThumbnailUrl }}" alt="">
         <div class="min-width-0">
-            <a class="block text-truncate color-primary-if-not-visited" href="{{ .Url }}">{{ .Title }}</a>
+            <a class="block text-truncate color-primary-if-not-visited" href="{{ .Url }}" target="_blank" rel="noreferrer">{{ .Title }}</a>
             <ul class="list-horizontal-text flex-nowrap">
                 <li class="shrink-0" {{ dynamicRelativeTimeAttrs .TimePosted }}></li>
                 <li class="min-width-0">

--- a/internal/glance/utils.go
+++ b/internal/glance/utils.go
@@ -119,14 +119,6 @@ func parseRFC3339Time(t string) time.Time {
 	return parsed
 }
 
-func boolToString(b bool, trueValue, falseValue string) string {
-	if b {
-		return trueValue
-	}
-
-	return falseValue
-}
-
 func normalizeVersionFormat(version string) string {
 	version = strings.ToLower(strings.TrimSpace(version))
 

--- a/internal/glance/widget-custom-api.go
+++ b/internal/glance/widget-custom-api.go
@@ -153,12 +153,12 @@ func (r *decoratedGJSONResult) String(key string) string {
 	return r.Get(key).String()
 }
 
-func (r *decoratedGJSONResult) Int(key string) int64 {
+func (r *decoratedGJSONResult) Int(key string) int {
 	if key == "" {
-		return r.Result.Int()
+		return int(r.Result.Int())
 	}
 
-	return r.Get(key).Int()
+	return int(r.Get(key).Int())
 }
 
 func (r *decoratedGJSONResult) Float(key string) float64 {
@@ -179,11 +179,11 @@ func (r *decoratedGJSONResult) Bool(key string) bool {
 
 var customAPITemplateFuncs = func() template.FuncMap {
 	funcs := template.FuncMap{
-		"toFloat": func(a int64) float64 {
+		"toFloat": func(a int) float64 {
 			return float64(a)
 		},
-		"toInt": func(a float64) int64 {
-			return int64(a)
+		"toInt": func(a float64) int {
+			return int(a)
 		},
 		"add": func(a, b float64) float64 {
 			return a + b

--- a/internal/glance/widget-dns-stats.go
+++ b/internal/glance/widget-dns-stats.go
@@ -644,7 +644,10 @@ func fetchPiholeSessionID(instanceURL string, client *http.Client, password stri
 	}
 
 	if jsonResponse.Session.SID == "" {
-		return "", errors.New("authentication response returned empty session ID")
+		return "", fmt.Errorf(
+			"authentication response returned empty session ID, status code %d, message '%s'",
+			response.StatusCode, jsonResponse.Session.Message,
+		)
 	}
 
 	return jsonResponse.Session.SID, nil

--- a/internal/glance/widget-videos.go
+++ b/internal/glance/widget-videos.go
@@ -56,7 +56,7 @@ func (widget *videosWidget) initialize() error {
 		widget.Channels = append(widget.Channels, make([]string, len(widget.Playlists))...)
 
 		for i := range widget.Playlists {
-			widget.Channels[initialLen+i] = "playlist:" + widget.Playlists[i]
+			widget.Channels[initialLen+i] = videosWidgetPlaylistPrefix + widget.Playlists[i]
 		}
 	}
 

--- a/pkg/glance/glance.go
+++ b/pkg/glance/glance.go
@@ -1,0 +1,9 @@
+package glance
+
+import (
+	g "github.com/glanceapp/glance/internal/glance"
+)
+
+func Serve(configPath string) error {
+	return g.ServeApp(configPath)
+}


### PR DESCRIPTION
I've been toying with the idea of building a small desktop app powered by Glance, fully packaged and without the dependency of an external browser. To do that, Glance would need to expose a public package that I could reuse. 

This is how such a public interface could look like, starting simple.

https://github.com/rubiojr/glance-embed is a sample app embedding Glance using this exposed package.

@svilenmarkov would something like this be accepted?

Mostly a request for comments, to figure out if this would be a welcome addition.
If something like this is to be accepted, it may be a good idea to add a context argument, so the Glance server can be shutdown gracefully programmatically.