### PR TITLE
make title-url of pihole and pihole-v6 default to /admin

### DIFF
--- a/internal/glance/widget-dns-stats.go
+++ b/internal/glance/widget-dns-stats.go
@@ -60,19 +60,16 @@ func makeDNSWidgetTimeLabels(format string) [8]string {
 	return labels
 }
 
-func getWidgetTitleURL(widget *dnsStatsWidget) string {
+func (widget *dnsStatsWidget) initialize() error {
+	titleURL := strings.TrimRight(widget.URL, "/")
 	switch widget.Service {
 	case dnsServicePihole, dnsServicePiholeV6:
-		return fmt.Sprintf("%s/admin", strings.TrimRight(widget.URL, "/"))
-	default:
-		return widget.URL
+		titleURL = titleURL + "/admin"
 	}
-}
 
-func (widget *dnsStatsWidget) initialize() error {
 	widget.
 		withTitle("DNS Stats").
-		withTitleURL(getWidgetTitleURL(widget)).
+		withTitleURL(titleURL).
 		withCacheDuration(10 * time.Minute)
 
 	switch widget.Service {


### PR DESCRIPTION
<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->

As the title says, PiHole's title-url defaults to `/` which you'd just get error 403

![error 403 pihole](https://github.com/user-attachments/assets/5ed91e6a-c9c6-41d8-8a8a-dc659e135adb)

This just adds `/admin` to it, not sure about other services though so I only added one for PiHole