### PR TITLE
Add bing and perplexity as search engines

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1001,6 +1001,8 @@ Either a value from the table below or a URL to a custom search engine. Use `{QU
 | ---- | --- |
 | duckduckgo | `https://duckduckgo.com/?q={QUERY}` |
 | google | `https://www.google.com/search?q={QUERY}` |
+| bing | `https://www.bing.com/search?q={QUERY}` |
+| perplexity | `https://www.perplexity.ai/search?q={QUERY}` |
 
 ##### `new-tab`
 When set to `true`, swaps the shortcuts for showing results in the same or new tab, defaulting to showing results in a new tab.

--- a/internal/glance/widget-search.go
+++ b/internal/glance/widget-search.go
@@ -33,6 +33,8 @@ func convertSearchUrl(url string) string {
 var searchEngines = map[string]string{
 	"duckduckgo": "https://duckduckgo.com/?q={QUERY}",
 	"google":     "https://www.google.com/search?q={QUERY}",
+	"bing":       "https://www.bing.com/search?q={QUERY}",
+	"perplexity": "https://www.perplexity.ai/search?q={QUERY}",
 }
 
 func (widget *searchWidget) initialize() error {


### PR DESCRIPTION
Adds two new search providers:

- [Bing](https://www.bing.com): `https://www.bing.com/search?q={QUERY}`
- [Perplexity](https://www.perplexity.ai): `https://www.perplexity.ai/search?q={QUERY}`