### PR TITLE
Add Kagi and Startpage as search engines

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1003,6 +1003,7 @@ Either a value from the table below or a URL to a custom search engine. Use `{QU
 | google | `https://www.google.com/search?q={QUERY}` |
 | bing | `https://www.bing.com/search?q={QUERY}` |
 | perplexity | `https://www.perplexity.ai/search?q={QUERY}` |
+| kagi | `https://kagi.com/search?q={QUERY}` |
 
 ##### `new-tab`
 When set to `true`, swaps the shortcuts for showing results in the same or new tab, defaulting to showing results in a new tab.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1004,6 +1004,7 @@ Either a value from the table below or a URL to a custom search engine. Use `{QU
 | bing | `https://www.bing.com/search?q={QUERY}` |
 | perplexity | `https://www.perplexity.ai/search?q={QUERY}` |
 | kagi | `https://kagi.com/search?q={QUERY}` |
+| startpage | `https://www.startpage.com/search?q={QUERY}` |
 
 ##### `new-tab`
 When set to `true`, swaps the shortcuts for showing results in the same or new tab, defaulting to showing results in a new tab.

--- a/internal/glance/widget-search.go
+++ b/internal/glance/widget-search.go
@@ -35,6 +35,8 @@ var searchEngines = map[string]string{
 	"google":     "https://www.google.com/search?q={QUERY}",
 	"bing":       "https://www.bing.com/search?q={QUERY}",
 	"perplexity": "https://www.perplexity.ai/search?q={QUERY}",
+	"kagi": "https://kagi.com/search?q={QUERY}",
+	"startpage": "https://www.startpage.com/search?q={QUERY}",
 }
 
 func (widget *searchWidget) initialize() error {


### PR DESCRIPTION
Added two more search engines:

- Kagi `https://kagi.com/search?q={QUERY}`
- Startpage `https://www.startpage.com/search?q={QUERY}`
