### PR TITLE
feat: add fallback icon and image on RSS feeds

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -592,6 +592,8 @@ An array of RSS/atom feeds. The title can optionally be changed.
 | limit | integer | no | | |
 | item-link-prefix | string | no | | |
 | headers | key (string) & value (string) | no | | |
+| fallback-icon | string | no | | URL to an icon to use if the feed doesn't provide one |
+| fallback-image | string | no | | URL to an image to use if the feed doesn't provide one |
 
 ###### `limit`
 The maximum number of articles to show from that specific feed. Useful if you have a feed which posts a lot of articles frequently and you want to prevent it from excessively pushing down articles from other feeds.
@@ -609,6 +611,43 @@ Optionally specify the headers that will be sent with the request. Example:
       headers:
         User-Agent: Custom User Agent
 ```
+
+###### `fallback-icon`
+If the feed doesn't provide an icon, this will be used instead. 
+
+```yaml
+- type: rss
+  feeds:
+    - url: https://domain.com/rss
+      fallback-icon: https://..../image.png
+```
+
+You can also directly use [Simple Icons](https://simpleicons.org/) via a `si:` prefix or [Dashboard Icons](https://github.com/walkxcode/dashboard-icons) via a `di:` prefix:
+
+```yaml
+- type: rss
+  feeds:
+    - url: https://domain.com/rss
+      fallback-icon: si:github
+```
+
+> [!WARNING]
+>
+> The `fallback-icon` property cannot be defined if `fallback-image` is also defined.
+
+###### `fallback-image`
+If the feed doesn't provide an image, this will be used instead. Example:
+
+```yaml
+- type: rss
+  feeds:
+    - url: https://domain.com/rss
+      fallback-icon: https://..../image.png
+```
+
+> [!WARNING]
+>
+> The `fallback-icon` property cannot be defined if `fallback-image` is also defined.
 
 ### Videos
 Display a list of the latest videos from specific YouTube channels.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -613,7 +613,7 @@ Optionally specify the headers that will be sent with the request. Example:
 ```
 
 ###### `fallback-icon`
-If the feed doesn't provide an icon, this will be used instead. 
+If the feed doesn't provide an image, this will be used instead. 
 
 ```yaml
 - type: rss

--- a/internal/glance/static/main.css
+++ b/internal/glance/static/main.css
@@ -1726,6 +1726,11 @@ details[open] .summary::after {
     height: 8.7rem;
 }
 
+.fallback-icon-thumbnail {
+    margin: auto;
+    height: 100%;
+}
+
 .twitch-category-thumbnail {
     width: 5rem;
     aspect-ratio: 3 / 4;

--- a/internal/glance/templates/rss-detailed-list.html
+++ b/internal/glance/templates/rss-detailed-list.html
@@ -5,7 +5,13 @@
     {{ range .Items }}
     <li class="flex gap-15 items-start row-reverse-on-mobile thumbnail-parent">
         <div class="thumbnail-container rss-detailed-thumbnail">
-            {{ if ne "" .ImageURL }}
+            {{ if and (eq "" .ImageURL) (ne "" .FallbackIconURL) }}
+            <div class="scale-half hide-on-mobile">
+                <img class="fallback-icon-thumbnail" loading="lazy" src="{{ .FallbackIconURL }}" alt="">
+            </div>
+            {{ else if and (eq "" .ImageURL) (ne "" .FallbackImageURL) }}
+            <img class="thumbnail" loading="lazy" src="{{ .FallbackImageURL }}" alt="">
+            {{ else if and (ne "" .ImageURL) (eq "" .FallbackImageURL) }}
             <img class="thumbnail" loading="lazy" src="{{ .ImageURL }}" alt="">
             {{ else }}
             <svg class="scale-half hide-on-mobile" stroke="var(--color-text-subdue)" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5">

--- a/internal/glance/templates/rss-horizontal-cards-2.html
+++ b/internal/glance/templates/rss-horizontal-cards-2.html
@@ -8,7 +8,13 @@
     <div class="cards-horizontal carousel-items-container"{{ if ne 0.0 .CardHeight }} style="--rss-card-height: {{ .CardHeight }}rem;"{{ end }}>
         {{ range .Items }}
         <div class="card rss-card-2 widget-content-frame thumbnail-parent">
-            {{ if ne "" .ImageURL }}
+            {{ if and (eq "" .ImageURL) (ne "" .FallbackIconURL) }}
+            <div class="rss-card-2-image scale-half hide-on-mobile">
+                <img class="fallback-icon-thumbnail" loading="lazy" src="{{ .FallbackIconURL }}" alt="">
+            </div>
+            {{ else if and (eq "" .ImageURL) (ne "" .FallbackImageURL) }}
+            <img class="rss-card-2-image thumbnail" loading="lazy" src="{{ .FallbackImageURL }}" alt="">
+            {{ else if and (ne "" .ImageURL) (eq "" .FallbackImageURL) }}
             <img class="rss-card-2-image thumbnail" loading="lazy" src="{{ .ImageURL }}" alt="">
             {{ else }}
             <svg class="rss-card-2-image" style="transform: scale(0.35) translateY(-25%)" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="var(--color-text-subdue)">

--- a/internal/glance/templates/rss-horizontal-cards.html
+++ b/internal/glance/templates/rss-horizontal-cards.html
@@ -8,7 +8,13 @@
     <div class="cards-horizontal carousel-items-container"{{ if ne 0.0 .ThumbnailHeight }} style="--rss-thumbnail-height: {{ .ThumbnailHeight }}rem;"{{ end }}>
         {{ range .Items }}
         <div class="card widget-content-frame thumbnail-parent">
-            {{ if ne "" .ImageURL }}
+            {{ if and (eq "" .ImageURL) (ne "" .FallbackIconURL) }}
+            <div class="rss-card-image scale-half hide-on-mobile">
+                <img class="fallback-icon-thumbnail" loading="lazy" src="{{ .FallbackIconURL }}" alt="">
+            </div>
+            {{ else if and (eq "" .ImageURL) (ne "" .FallbackImageURL) }}
+            <img class="rss-card-image thumbnail" loading="lazy" src="{{ .FallbackImageURL }}" alt="">
+            {{ else if and (ne "" .ImageURL) (eq "" .FallbackImageURL) }}
             <img class="rss-card-image thumbnail" loading="lazy" src="{{ .ImageURL }}" alt="">
             {{ else }}
             <svg class="rss-card-image" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="var(--color-text-subdue)">


### PR DESCRIPTION
<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->

Hi, just a little enhancement on the RSS widget.

This will allow widget users to define a fallback image to quickly identify RSS feed item if not image is provided by the RSS feed provider.

As an example, [CERT-FR](https://www.cert.ssi.gouv.fr/) [RSS](https://www.cert.ssi.gouv.fr/feed/) feed doesn't provide an image.

Before : 
![image](https://github.com/user-attachments/assets/a2e9da6f-695d-4cae-b36b-06ac28f4bd1d)

After :
![image](https://github.com/user-attachments/assets/5d33df61-331a-435c-9544-14f10664c85a)


Thanks a lot for this amazing tool.