### PR TITLE
FIx Ignore Variables in Commented-Out YAML Sections

### DIFF
--- a/internal/glance/utils.go
+++ b/internal/glance/utils.go
@@ -19,6 +19,16 @@ func percentChange(current, previous float64) float64 {
 	return (current/previous - 1) * 100
 }
 
+func computeLineStarts(contents []byte) []int {
+	lineStarts := []int{0}
+	for i, b := range contents {
+		if b == '\n' {
+			lineStarts = append(lineStarts, i+1)
+		}
+	}
+	return lineStarts
+}
+
 func extractDomainFromUrl(u string) string {
 	if u == "" {
 		return ""


### PR DESCRIPTION
fixed glance trying to use env variables in glance.yml when they are commented out, no more backslash nonsense.
