### PR TITLE
Search bar acts like address bar feature implemented

### DIFF
--- a/internal/glance/static/js/main.js
+++ b/internal/glance/static/js/main.js
@@ -94,6 +94,27 @@ function updateRelativeTimeForElements(elements)
     }
 }
 
+function isValidUrl(string){
+	let url;
+	try {
+		url = new URL(string);
+	} catch ({ name, message }) {
+		const pattern = /^(?:[a-z0-9-]+\.)+[a-z]+$/
+		if (pattern.test(string)){
+			return true;
+		}
+		return false;  
+	}
+	return url.protocol === "http:" || url.protocol === "https:";
+}
+
+function toUrl(link){
+	if (link.search(/^http[s]?\:\/\//) == -1) {
+        link = 'http://' + link;
+    }
+    return link;
+}
+
 function setupSearchBoxes() {
     const searchWidgets = document.getElementsByClassName("search");
 
@@ -126,6 +147,10 @@ function setupSearchBoxes() {
 
             if (event.key == "Enter") {
                 const input = inputElement.value.trim();
+				if (isValidUrl(input)) {
+					openURLInNewTab(toUrl(input));
+					return;
+				}
                 let query;
                 let searchUrlTemplate;
 


### PR DESCRIPTION
# Feature from https://github.com/glanceapp/glance/issues/229 issue implemented
That is the second PR i made about this feature. The first [one](https://github.com/glanceapp/glance/pull/256) was closed by me, because i messed up with resolving merge conflicts.

This time all string that looks like link will be interpreted as a valid links. For example:
- `http://google.com`
- `https://google.com`
- `google.com`
- `www.google.com`

Also i want to add a schebang for external links, like it already implemented with youtube for example. Is it a good idea? If it is i will create a separate PR.
