### PR TITLE
Implement optional description for bookmarks widget

### DIFF
--- a/internal/glance/templates/bookmarks.html
+++ b/internal/glance/templates/bookmarks.html
@@ -15,6 +15,7 @@
             {{ end }}
             <a href="{{ .URL | safeURL }}" class="bookmarks-link {{ if .HideArrow }}bookmarks-link-no-arrow {{ end }}color-highlight size-h4" {{ if .Target }}target="{{ .Target }}"{{ end }} rel="noreferrer">{{ .Title }}</a>
         </li>
+        <p class="color-text size-h5">{{ .Description }}</p>
         {{ end }}
         </ul>
     </div>

--- a/internal/glance/widget-bookmarks.go
+++ b/internal/glance/widget-bookmarks.go
@@ -16,9 +16,10 @@ type bookmarksWidget struct {
 		HideArrow bool           `yaml:"hide-arrow"`
 		Target    string         `yaml:"target"`
 		Links     []struct {
-			Title string          `yaml:"title"`
-			URL   string          `yaml:"url"`
-			Icon  customIconField `yaml:"icon"`
+			Title       string          `yaml:"title"`
+			Description string          `yaml:"description"`
+			URL         string          `yaml:"url"`
+			Icon        customIconField `yaml:"icon"`
 			// we need a pointer to bool to know whether a value was provided,
 			// however there's no way to dereference a pointer in a template so
 			// {{ if not .SameTab }} would return true for any non-nil pointer


### PR DESCRIPTION
# Implement feature from #379 issue

`description` option was introduced in glance.yml file

## How it looks like in desktop mode
![image](https://github.com/user-attachments/assets/5101b8ce-8c9f-4259-8f14-23e842b96244)

## How it looks like on mobile
![image](https://github.com/user-attachments/assets/7165bd58-f433-478a-b193-5d553029c814)

