### PR TITLE
add wait-last-request for custom-api

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1342,7 +1342,7 @@ Examples:
 | allow-insecure | boolean | no | false |
 | skip-json-validation | boolean | no | false |
 | wait-last-request | boolean | no | false |
-| ignore-timeout | boolean | no | false |
+| skip-timeout-error | boolean | no | false |
 | template | string | yes | |
 | parameters | key (string) & value (string|array) | no | |
 | subrequests | map of requests | no | |
@@ -1400,8 +1400,8 @@ When set to `true`, will wait for the previous request to finish before running.
 >
 > Multiple usage of this property will slow your page load time depending on the API's response time by another timeout time each succession of the property.
 
-#### `ignore-timeout`
-When set to `true`, ignores the timeout error that prevents the widget from loading entirely. This is useful when you have a query that only triggers an action and you don't necessarily need the data. You can still check for `.Response.Status` as it should return `504` before using the data if needed.
+#### `skip-timeout-error`
+When set to `true`, skips the timeout error that prevents the widget from loading entirely. This is useful when you have a query that only triggers an action and you don't necessarily need the data. You can still check for `.Response.Status` as it should return `504` before using the data if needed.
 
 ##### `template`
 The template that will be used to display the data. It relies on Go's `html/template` package so it's recommended to go through [its documentation](https://pkg.go.dev/text/template) to understand how to do basic things such as conditionals, loops, etc. In addition, it also uses [tidwall's gjson](https://github.com/tidwall/gjson) package to parse the JSON data so it's worth going through its documentation if you want to use more advanced JSON selectors. You can view additional examples with explanations and function definitions [here](custom-api.md).

--- a/internal/glance/widget-custom-api.go
+++ b/internal/glance/widget-custom-api.go
@@ -34,7 +34,7 @@ type CustomAPIRequest struct {
 	Body               any                  `yaml:"body"`
 	SkipJSONValidation bool                 `yaml:"skip-json-validation"`
 	WaitLastRequest    bool                 `yaml:"wait-last-request"`
-	IgnoreTimeout     bool                 `yaml:"ignore-timeout"`
+	SkipTimeoutError   bool                 `yaml:"skip-timeout-error"`
 	bodyReader         io.ReadSeeker        `yaml:"-"`
 	httpRequest        *http.Request        `yaml:"-"`
 }
@@ -193,7 +193,7 @@ func fetchCustomAPIRequest(ctx context.Context, req *CustomAPIRequest) (*customA
 	client := ternary(req.AllowInsecure, defaultInsecureHTTPClient, defaultHTTPClient)
 	resp, err := client.Do(req.httpRequest.WithContext(ctx))
 	if err != nil {
-		if req.IgnoreTimeout && errors.Is(err, context.DeadlineExceeded) {
+		if req.SkipTimeoutError && errors.Is(err, context.DeadlineExceeded) {
 			resp = &http.Response{
 				Status: err.Error(),
 				StatusCode: 504,


### PR DESCRIPTION
<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->

For https://github.com/glanceapp/glance/issues/568

#### Config example:
```yaml
- type: custom-api
  url: https:${WEBSERVER_URL}/data          # Replaces the value of the key timestamp inside file data.json with the current timestamp
  method: post                              # Notice post
  skip-timeout-error: true                  # Example in the sub2, this should skip timeout error whenever it reaches it as the data from this request isn't needed
  subrequests:
    sub1:
      url: https:${WEBSERVER_URL}/data          # A get request the fetches a file data.json that has a timestamp key
      wait-last-request: true                   # The feature added, this waits for the previous request
    sub2:
      url: https:${WEBSERVER_URL}/slow          # Just a request that finishes up after 10s to simulate timeout
      skip-timeout-error: true                  # Just an example
  cache: 1s
  template: |
    <div><pre>POST:     {{ (.Subrequest "sub1").JSON.String "timestamp" }}</pre></div>
    <div><pre>GET:      {{ .JSON.String "timestamp" }}</pre></div>
    <div><pre>Matched?: {{ eq (.JSON.String "timestamp") ((.Subrequest "sub1").JSON.String "timestamp") }}</pre></div>
    <div><pre>SUB2:     {{ (.Subrequest "sub2").Response.Status }}</pre></div>
```

#### Output:
```
POST:     1744133075172
GET:      1744133075172
Matched?: true
SUB2:     Get "https://<redacted>/slow": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

Setting `wait-last-request: false` or not setting it at all would make the `Matched?:` value randomized (GET would get the previous data before the POST happened or GET the latest POST data) since requests are concurrent and would it be unpredictable.

> [!CAUTION]
>
> Multiple SUCCESSIVE usage of this property in the same widget can slow your page load time depending on the API's response by another 1~5 seconds (timeout limit) each `wait-last-request`.