### PR TITLE
Allow to specify branch for repository widget

### DIFF
--- a/internal/glance/templates/repository.html
+++ b/internal/glance/templates/repository.html
@@ -9,7 +9,7 @@
 
 {{ if gt (len .Repository.Commits) 0 }}
 <hr class="margin-block-8">
-<a class="text-compact" href="https://github.com/{{ $.Repository.Name }}/commits" target="_blank" rel="noreferrer">Last {{ .CommitsLimit }} commits</a>
+<a class="text-compact" href="https://github.com/{{ $.Repository.Name }}/commits/{{ .RepositoryBranch}}" target="_blank" rel="noreferrer">Last {{ .CommitsLimit }} commits <span class="color-primary">{{ .RepositoryBranch }}</span></a>
 <div class="flex gap-7 size-h5 margin-top-3">
     <ul class="list list-gap-2">
         {{ range .Repository.Commits }}


### PR DESCRIPTION
# This implements the feature from #315 
This feature is possible because of `sha` query parameter in `https://api.github.com/repos/commits` endpoint.

From the [documentation](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28):
> `sha` string
> SHA or branch to start listing commits from. Default: the repository’s default branch (usually main).

## New yaml variable introduced
- `branch` string, must be the same as branch name from remote repo.

## How it looks like without specifying the branch name
![image](https://github.com/user-attachments/assets/a50f99a2-adf7-499c-bdff-ccf6fce878cf)


## How it looks like with branch name
![image](https://github.com/user-attachments/assets/87060ad7-293f-410f-b222-50520f8b59f5)

