### PR TITLE
Support embed icons on bookmarks URLs

### DIFF
--- a/internal/glance/config-fields.go
+++ b/internal/glance/config-fields.go
@@ -3,6 +3,7 @@ package glance
 import (
 	"crypto/tls"
 	"fmt"
+	"html/template"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -115,7 +116,7 @@ func (d *durationField) UnmarshalYAML(node *yaml.Node) error {
 }
 
 type customIconField struct {
-	URL        string
+	URL        template.URL
 	IsFlatIcon bool
 	// TODO: along with whether the icon is flat, we also need to know
 	// whether the icon is black or white by default in order to properly
@@ -127,13 +128,13 @@ func newCustomIconField(value string) customIconField {
 
 	prefix, icon, found := strings.Cut(value, ":")
 	if !found {
-		field.URL = value
+		field.URL = template.URL(value)
 		return field
 	}
 
 	switch prefix {
 	case "si":
-		field.URL = "https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/" + icon + ".svg"
+		field.URL = template.URL("https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/" + icon + ".svg")
 		field.IsFlatIcon = true
 	case "di", "sh":
 		// syntax: di:<icon_name>[.svg|.png]
@@ -152,12 +153,12 @@ func newCustomIconField(value string) customIconField {
 		}
 
 		if prefix == "di" {
-			field.URL = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/" + ext + "/" + basename + "." + ext
+			field.URL = template.URL("https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/" + ext + "/" + basename + "." + ext)
 		} else {
-			field.URL = "https://cdn.jsdelivr.net/gh/selfhst/icons/" + ext + "/" + basename + "." + ext
+			field.URL = template.URL("https://cdn.jsdelivr.net/gh/selfhst/icons/" + ext + "/" + basename + "." + ext)
 		}
 	default:
-		field.URL = value
+		field.URL = template.URL(value)
 	}
 
 	return field

--- a/internal/glance/templates.go
+++ b/internal/glance/templates.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"math"
 	"strconv"
+	"strings"
 
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
@@ -53,6 +54,7 @@ var globalTemplateFunctions = template.FuncMap{
 
 		return template.HTML(value + ` <span class="color-base size-h5">` + label + `</span>`)
 	},
+	"hasPrefix": strings.HasPrefix,
 }
 
 func mustParseTemplate(primary string, dependencies ...string) *template.Template {

--- a/internal/glance/templates/bookmarks.html
+++ b/internal/glance/templates/bookmarks.html
@@ -13,7 +13,7 @@
             <div class="flex items-center gap-10">
                 {{- if ne "" .Icon.URL }}
                 <div class="bookmarks-icon-container">
-                    <img class="bookmarks-icon{{ if .Icon.IsFlatIcon }} flat-icon{{ end }}" src="{{ if hasPrefix .Icon.URL "data:image/" }}{{ .Icon.URL | safeURL }}{{ else }}{{ .Icon.URL }}{{ end }}" alt="" loading="lazy">
+                    <img class="bookmarks-icon{{ if .Icon.IsFlatIcon }} flat-icon{{ end }}" src="{{ .Icon.URL }}" alt="" loading="lazy">
                 </div>
                 {{- end }}
                 <a href="{{ .URL | safeURL }}" class="bookmarks-link {{ if .HideArrow }}bookmarks-link-no-arrow {{ end }}color-highlight size-h4" {{ if .Target }}target="{{ .Target }}"{{ end }} rel="noreferrer">{{ .Title }}</a>

--- a/internal/glance/templates/bookmarks.html
+++ b/internal/glance/templates/bookmarks.html
@@ -13,7 +13,7 @@
             <div class="flex items-center gap-10">
                 {{- if ne "" .Icon.URL }}
                 <div class="bookmarks-icon-container">
-                    <img class="bookmarks-icon{{ if .Icon.IsFlatIcon }} flat-icon{{ end }}" src="{{ .Icon.URL }}" alt="" loading="lazy">
+                    <img class="bookmarks-icon{{ if .Icon.IsFlatIcon }} flat-icon{{ end }}" src="{{ if hasPrefix .Icon.URL "data:image/" }}{{ .Icon.URL | safeURL }}{{ else }}{{ .Icon.URL }}{{ end }}" alt="" loading="lazy">
                 </div>
                 {{- end }}
                 <a href="{{ .URL | safeURL }}" class="bookmarks-link {{ if .HideArrow }}bookmarks-link-no-arrow {{ end }}color-highlight size-h4" {{ if .Target }}target="{{ .Target }}"{{ end }} rel="noreferrer">{{ .Title }}</a>


### PR DESCRIPTION
Added option to use data URLs for icons on bookmark widget.

Ex.:
```yaml
widgets:
  - type: bookmarks
    links:
      - title: Apple TV+
        url: https://tv.apple.com/
        icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAIAAADYYG7QAAACCklEQVRYCe1WUZHEIAyNBCQgoRKQgIRKQAIOkIAEJEQCEpCABK6zuX3LFK69m7mb2w/42TSE5uW9hC7RWouBxcBiYDGwGFgM/CMDxhjvvdb6HzG8UocQ2mO9BSBrraDJOb8wPi1hznu/7/vT98e/KaXWWq1127Yxlfde4DLzuPtrHqWUMUYpRUQhhJSSeawR058DUkoxsxTdWkspee+FJHHWWkUdrbUxJsYIQQW09Jl/rkPTE0/Hcdm8V1kplXMGmgtDWmcacCQjItRwlHQCVGuVg/eAUO40E5wxxiMHxIJfDAGEUWitifQCyxiD+N5/Av35COw4MxqlFIm+loyI8DZrLfLhBhmZQ8zLGNOPnhDC60DH0zhl4FsYlVNoiXu9iGhMP3pEEWCCcCMgqFNrlXittbyw1nqv1zcBnRJfACKiUoogkPvCOSePPWeobWJA9ZGY3tOzfQ0IHXMavb6rJjjggup9+qkN4a4Bbdsmx+WzIzYURN4vjX5WpzjgxIxcA+pVg16nsfgSjWxgCpB7auD+BaBSyrRPgePUTzc4sA2SpzjECXqIaN93RNZambnvMCLCZEkYrjFkvDdQEzL1Rs65Z2L82qC9kKln/Wd64RXOOWZOKe37rpTSWocQmDnG2KOReKWUcy6lxI81TpC1VraY+S3+4qHOZSwGFgOLgcXAYmAxsBh4KwY+AA8f0pelvldGAAAAAElFTkSuQmCC
```