### PR TITLE
﻿[sensors] allow sensor readings when there are warnings

### DIFF
--- a/internal/glance/cli.go
+++ b/internal/glance/cli.go
@@ -96,22 +96,22 @@ func parseCliOptions() (*cliOptions, error) {
 func cliSensorsPrint() int {
 	tempSensors, err := sensors.SensorsTemperatures()
 	if err != nil {
-		fmt.Printf("Failed to retrieve list of sensors: %v\n", err)
+		fmt.Printf("Errors encountered while retrieving list of sensors:\n %v\n", err)
 		if warns, ok := err.(*sensors.Warnings); ok {
 			for _, w := range warns.List {
 				fmt.Printf(" - %v\n", w)
 			}
 		}
-		return 1
 	}
 
-	if len(tempSensors) == 0 {
+	if tempSensors == nil || len(tempSensors) == 0 {
 		fmt.Println("No sensors found")
 		return 0
 	}
 
+	fmt.Println("Sensors found:")
 	for _, sensor := range tempSensors {
-		fmt.Printf("%s: %.1f°C\n", sensor.SensorKey, sensor.Temperature)
+		fmt.Printf(" %s: %.1f°C\n", sensor.SensorKey, sensor.Temperature)
 	}
 
 	return 0

--- a/internal/glance/cli.go
+++ b/internal/glance/cli.go
@@ -96,15 +96,19 @@ func parseCliOptions() (*cliOptions, error) {
 func cliSensorsPrint() int {
 	tempSensors, err := sensors.SensorsTemperatures()
 	if err != nil {
-		fmt.Printf("Errors encountered while retrieving list of sensors:\n %v\n", err)
 		if warns, ok := err.(*sensors.Warnings); ok {
+			fmt.Printf("Could not retrieve information for some sensors (%v):\n", err)
 			for _, w := range warns.List {
 				fmt.Printf(" - %v\n", w)
 			}
+			fmt.Println()
+		} else {
+			fmt.Printf("Failed to retrieve sensor information: %v\n", err)
+			return 1
 		}
 	}
 
-	if tempSensors == nil || len(tempSensors) == 0 {
+	if len(tempSensors) == 0 {
 		fmt.Println("No sensors found")
 		return 0
 	}

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -205,7 +205,7 @@ func Collect(req *SystemInfoRequest) (*SystemInfo, []error) {
 	// also disabled on openbsd because it's not implemented by go-psutil
 	if runtime.GOOS != "windows" && runtime.GOOS != "openbsd" {
 		sensorReadings, err := sensors.SensorsTemperatures()
-		if err == nil {
+		if sensorReadings != nil && len(sensorReadings) > 0 {
 			if req.CPUTempSensor != "" {
 				for i := range sensorReadings {
 					if sensorReadings[i].SensorKey == req.CPUTempSensor {

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -201,11 +201,12 @@ func Collect(req *SystemInfoRequest) (*SystemInfo, []error) {
 	// currently disabled on Windows because it requires elevated privilidges, otherwise
 	// keeps returning a single sensor with key "ACPI\\ThermalZone\\TZ00_0" which
 	// doesn't seem to be the CPU sensor or correspond to anything useful when
-	// compared against the temperatures Libre Hardware Monitor reports
-	// also disabled on openbsd because it's not implemented by go-psutil
-	if runtime.GOOS != "windows" && runtime.GOOS != "openbsd" {
+	// compared against the temperatures Libre Hardware Monitor reports.
+	// Also disabled on the bsd's because it's not implemented by go-psutil for them
+	if runtime.GOOS != "windows" && runtime.GOOS != "openbsd" && runtime.GOOS != "netbsd" && runtime.GOOS != "freebsd" {
 		sensorReadings, err := sensors.SensorsTemperatures()
-		if sensorReadings != nil && len(sensorReadings) > 0 {
+		_, errIsWarning := err.(*sensors.Warnings)
+		if err == nil || errIsWarning {
 			if req.CPUTempSensor != "" {
 				for i := range sensorReadings {
 					if sensorReadings[i].SensorKey == req.CPUTempSensor {


### PR DESCRIPTION
<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->
New to Go, I'm not entirely sure the `nil` checks are required.

Before:
```
/app # ./glance sensors:print
Failed to retrieve list of sensors: Number of warnings: 1
 - read /sys/class/hwmon/hwmon4/temp1_input: no data available
```

After:
```
/app # ./glance sensors:print
Errors encountered while retrieving list of sensors:
 Number of warnings: 1
 - read /sys/class/hwmon/hwmon4/temp1_input: no data available
Sensors found:
 acpitz: 27.8°C
 acpitz: 29.8°C
 pch_skylake: 36.5°C
 jc42: 27.6°C
 coretemp_package_id_0: 59.0°C
 coretemp_core_0: 56.0°C
 coretemp_core_1: 59.0°C
 coretemp_core_2: 59.0°C
 coretemp_core_3: 56.0°C
```
![image](https://github.com/user-attachments/assets/ead37775-6036-44f4-ae02-857a02d1e6f1)
