### PR TITLE
Add `MountBarLimit` Option

### DIFF
--- a/internal/glance/templates/server-stats.html
+++ b/internal/glance/templates/server-stats.html
@@ -125,10 +125,10 @@
                 </div>
                 {{- end }}
                 <div class="progress-bar progress-bar-combined">
-                    {{- if .Info.Mountpoints }}
-                    <div class="progress-value{{ if ge ((index .Info.Mountpoints 0).UsedPercent) 85 }} progress-value-notice{{ end }}" style="--percent: {{ (index .Info.Mountpoints 0).UsedPercent }}"></div>
-                    {{- if ge (len .Info.Mountpoints) 2 }}
-                    <div class="progress-value{{ if ge ((index .Info.Mountpoints 1).UsedPercent) 85 }} progress-value-notice{{ end }}" style="--percent: {{ (index .Info.Mountpoints 1).UsedPercent }}"></div>
+                    {{$limit := .MountBarLimit}}
+                    {{- range $i,$mount := .Info.Mountpoints }}
+                    {{if lt $i $limit }}
+                    <div class="progress-value{{ if ge .UsedPercent 85 }} progress-value-notice{{ end }}" style="--percent: {{ .UsedPercent }}"></div>
                     {{- end }}
                     {{- end }}
                 </div>

--- a/internal/glance/widget-server-stats.go
+++ b/internal/glance/widget-server-stats.go
@@ -91,6 +91,7 @@ type serverStatsRequest struct {
 	StatusText                 string              `yaml:"-"`
 	Name                       string              `yaml:"name"`
 	HideSwap                   bool                `yaml:"hide-swap"`
+	MountBarLimit   		   int                 `yaml:"mount-bar-limit"`
 	Type                       string              `yaml:"type"`
 	URL                        string              `yaml:"url"`
 	Token                      string              `yaml:"token"`


### PR DESCRIPTION
I wanted to see all 4 of my drives in the bars inside of the server stats widget opposed to the hard-coded two, so I added support for this with a new `mount-bar-limit` option, so people can choose how many they want to display.

![A glance configuration file with a new mount-bar-limit option being set to 4.](https://github.com/user-attachments/assets/af95a9b3-47df-4080-9938-c87c25c18266)

![A image of the server stats widget with 4 bars showing the drives opposed to two.](https://github.com/user-attachments/assets/4167e1b1-a701-4292-bf1f-795837e42380)
