### PR TITLE
Minor design tweak, polishing up the polyline corners 

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,6 +5,7 @@
   - [Auto reload](#auto-reload)
   - [Environment variables](#environment-variables)
   - [Including other config files](#including-other-config-files)
+  - [Config schema](#config-schema)
 - [Server](#server)
 - [Document](#document)
 - [Branding](#branding)
@@ -148,6 +149,10 @@ docker run --rm -v ./glance.yml:/app/config/glance.yml glanceapp/glance config:p
 ```
 
 This assumes that the config you want to print is in your current working directory and is named `glance.yml`.
+
+## Config schema
+
+For property descriptions, validation and autocompletion of the config within your IDE, @not-first has kindly created a [schema](https://github.com/not-first/glance-schema). Massive thanks to them for this, go check it out and give them a star!
 
 ## Server
 Server configuration is done through a top level `server` property. Example:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1583,7 +1583,7 @@ The title used to indicate the site.
 
 `url`
 
-The public facing URL of a monitored service, the user will be redirected here. If `check-url` is not specified, this is used as the status check.
+The URL of the monitored service, which must be reachable by Glance, and will be used as the link to go to when clicking on the title. If `check-url` is not specified, this is used as the status check.
 
 `check-url`
 

--- a/internal/glance/cli.go
+++ b/internal/glance/cli.go
@@ -106,8 +106,6 @@ func cliSensorsPrint() int {
 			fmt.Printf("Failed to retrieve sensor information: %v\n", err)
 			return 1
 		}
-
-		return 1
 	}
 
 	if len(tempSensors) == 0 {

--- a/internal/glance/templates/markets.html
+++ b/internal/glance/templates/markets.html
@@ -11,7 +11,7 @@
 
         <a class="market-chart" {{ if ne "" .ChartLink }} href="{{ .ChartLink }}" target="_blank" rel="noreferrer"{{ end }}>
             <svg class="market-chart shrink-0" viewBox="0 0 100 50">
-                <polyline fill="none" stroke="var(--color-text-subdue)" stroke-width="1.5px" points="{{ .SvgChartPoints }}" vector-effect="non-scaling-stroke"></polyline>
+                <polyline fill="none" stroke="var(--color-text-subdue)" stroke-linecap="round" stroke-width="1.5px" points="{{ .SvgChartPoints }}" vector-effect="non-scaling-stroke"></polyline>
             </svg>
         </a>
 

--- a/internal/glance/templates/markets.html
+++ b/internal/glance/templates/markets.html
@@ -11,7 +11,7 @@
 
         <a class="market-chart" {{ if ne "" .ChartLink }} href="{{ .ChartLink }}" target="_blank" rel="noreferrer"{{ end }}>
             <svg class="market-chart shrink-0" viewBox="0 0 100 50">
-                <polyline fill="none" stroke="var(--color-text-subdue)" stroke-linecap="round" stroke-width="1.5px" points="{{ .SvgChartPoints }}" vector-effect="non-scaling-stroke"></polyline>
+                <polyline fill="none" stroke="var(--color-text-subdue)" stroke-linejoin="round" stroke-width="1.5px" points="{{ .SvgChartPoints }}" vector-effect="non-scaling-stroke"></polyline>
             </svg>
         </a>
 


### PR DESCRIPTION
Adds a `stroke-linejoin="round"` to the polyline to ensure that they connect cleanly and look cohesive with the rest of the design of Glance. Ref: [MDN docs for polyline joins](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/stroke-linejoin#round). This shouldn't be noticeable for the vast majority of folks and is usually only visible at higher zoom levels. I've included a screen. Included a few screenshots of the changes:

Dark Mode: 

<img src="https://github.com/user-attachments/assets/2a299e88-0bf4-40f2-a1c0-0b0b9f568184" width=75% height=75%>

Light Mode:
<img src="https://github.com/user-attachments/assets/164c52ec-7f36-4a94-ba2b-fed025f51540" width=75% height=75%>