### PR TITLE
Add ControlD DNS service

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2279,7 +2279,7 @@ Whether to only show running containers. If set to `true` only containers that a
 | glance.category | The category of the container. Used to filter containers by category. |
 
 ### DNS Stats
-Display statistics from a self-hosted ad-blocking DNS resolver such as AdGuard Home, Pi-hole, or Technitium.
+Display statistics from a self-hosted ad-blocking DNS resolver such as AdGuard Home, Pi-hole, Technitium, or Controld.
 
 Example:
 
@@ -2297,24 +2297,24 @@ Preview:
 
 > [!NOTE]
 >
-> When using AdGuard Home the 3rd statistic on top will be the average latency and when using Pi-hole or Technitium it will be the total number of blocked domains from all adlists.
+> When using AdGuard Home the 3rd statistic on top will be the average latency and when using Pi-hole, Technitium, or Controld it will be the total number of blocked domains from all adlists.
 
 #### Properties
 
-| Name | Type | Required | Default |
-| ---- | ---- | -------- | ------- |
-| service | string | no | pihole |
-| allow-insecure | bool | no | false |
-| url | string | yes |  |
-| username | string | when service is `adguard` |  |
-| password | string | when service is `adguard` or `pihole-v6` |  |
-| token | string | when service is `pihole` |  |
-| hide-graph | bool | no | false |
-| hide-top-domains | bool | no | false |
-| hour-format | string | no | 12h |
+| Name             | Type   | Required                                              | Default |
+|------------------|--------|-------------------------------------------------------|---------|
+| service          | string | no                                                    | pihole  |
+| allow-insecure   | bool   | no                                                    | false   |
+| url              | string | yes                                                   |         |
+| username         | string | when service is `adguard`                             |         |
+| password         | string | when service is `adguard` or `pihole-v6`              |         |
+| token            | string | when service is `pihole`, `technitium`, or `controld` |         |
+| hide-graph       | bool   | no                                                    | false   |
+| hide-top-domains | bool   | no                                                    | false   |
+| hour-format      | string | no                                                    | 12h     |
 
 ##### `service`
-Either `adguard`, `technitium`, or `pihole` (major version 5 and below) or `pihole-v6` (major version 6 and above).
+Either `adguard`, `technitium`, `controld`, or `pihole` (major version 5 and below) or `pihole-v6` (major version 6 and above).
 
 ##### `allow-insecure`
 Whether to allow invalid/self-signed certificates when making the request to the service.
@@ -2332,6 +2332,8 @@ Also required when using Pi-hole major version 6 and above, where the password i
 
 ##### `token`
 Required when using Pi-hole major version 5 or earlier. The API token which can be found in `Settings -> API -> Show API token`.
+
+Required when using Controld, an API token can be created at `Preferences > API > Add`.
 
 Also required when using Technitium, an API token can be generated at `Administration -> Sessions -> Create Token`.
 

--- a/internal/glance/widget-dns-stats.go
+++ b/internal/glance/widget-dns-stats.go
@@ -315,8 +315,6 @@ func fetchControldStats(instanceURL string, allowInsecure bool, token string, no
 		return nil, err
 	}
 
-	fmt.Println(timeSeriesResponseJson)
-
 	domainsRequestURL := strings.TrimRight(instanceURL, "/") +
 		fmt.Sprintf("/reports/dns-queries/blocked-by-domain/pie-chart?startTs=%d", startTs)
 
@@ -330,8 +328,6 @@ func fetchControldStats(instanceURL string, allowInsecure bool, token string, no
 	if err != nil {
 		return nil, err
 	}
-
-	fmt.Println(domainsResponseJson)
 
 	totalQueries := 0
 	blockedQueries := 0
@@ -347,6 +343,7 @@ func fetchControldStats(instanceURL string, allowInsecure bool, token string, no
 	stats := &dnsStats{
 		TotalQueries:      totalQueries,
 		BlockedQueries:    blockedQueries,
+		DomainsBlocked:    len(domainsResponseJson.Body.Queries),
 		BlockedPercent:    int(float64(blockedQueries) / float64(totalQueries) * 100),
 		TopBlockedDomains: make([]dnsStatsBlockedDomain, 0, topBlockedDomainsCount),
 	}


### PR DESCRIPTION
Adds the ability to use ControlD as a service provider in the DNS Stats widget.