### PR TITLE
Add Mod operation

### DIFF
--- a/docs/custom-api.md
+++ b/docs/custom-api.md
@@ -238,7 +238,7 @@ Output:
 <div>90</div>
 ```
 
-Other operations include `add`, `mul`, and `div`.
+Other operations include `add`, `mul`, `div` and `mod`.
 
 <hr>
 
@@ -431,6 +431,7 @@ The following helper functions provided by Glance are available:
 - `sub(a, b float) float`: Subtracts two numbers.
 - `mul(a, b float) float`: Multiplies two numbers.
 - `div(a, b float) float`: Divides two numbers.
+- `mod(a, b int) int`: Remainder after dividing a by b (a % b).
 - `formatApproxNumber(n int) string`: Formats a number to be more human-readable, e.g. 1000 -> 1k.
 - `formatNumber(n float|int) string`: Formats a number with commas, e.g. 1000 -> 1,000.
 - `trimPrefix(prefix string, str string) string`: Trims the prefix from a string.

--- a/internal/glance/widget-custom-api.go
+++ b/internal/glance/widget-custom-api.go
@@ -414,6 +414,14 @@ func customAPIDoMathOp[T int | float64](a, b T, op string) T {
 			return 0
 		}
 		return a / b
+	case "mod":
+		ai, bi := any(a), any(b)
+		aint, aok := ai.(int)
+		bint, bok := bi.(int)
+		if aok && bok && bint != 0 {
+			return T(aint % bint)
+		}
+		return 0
 	}
 	return 0
 }
@@ -478,6 +486,9 @@ var customAPITemplateFuncs = func() template.FuncMap {
 		},
 		"div": func(a, b any) any {
 			return doMathOpWithAny(a, b, "div")
+		},
+		"mod": func(a, b int) any {
+			return doMathOpWithAny(a, b, "mod")
 		},
 		"now": func() time.Time {
 			return time.Now()


### PR DESCRIPTION
<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->

Currently the MOD operation is not available in Custom-api. Some additional mathematical calculations could be performed on Glance side if this operation was available as a function.

Introducing `mod(a, b int) int`: Remainder after dividing a by b (a % b).
Uses https://go.dev/ref/spec#Arithmetic_operators

This PR aims to resolve issue #641 

Tests:
```
- type: custom-api
            template: |
              <p class="size-h4 color-paragraph">Tests for mod with custom-api</p>
              <div>{{ mod 10 3 }}  == 1</div>
              <div>{{ mod 10 0 }}  == 0</div>
              <div>{{ mod 0 10 }}  == 0</div>
              <div>{{ mod -10 3 }}  == -1</div>
              <div>{{ mod 10 -3 }}  == 1</div>
              <div>{{ mod -10 -3 }}  == -1</div>
              <div>{{ mod 0 0 }}  == 0</div>
              <div>{{ mod 54 7 }}  == 5</div>
              <div>{{ mod 7 54 }}  == 7</div>
```
Results:
![image](https://github.com/user-attachments/assets/d0d0c7a9-df84-46e8-9ebe-2cb5fc7fb300)

