### PR TITLE
Add http proxy support

### DIFF
--- a/internal/glance/widget-utils.go
+++ b/internal/glance/widget-utils.go
@@ -26,6 +26,7 @@ const defaultClientTimeout = 5 * time.Second
 var defaultHTTPClient = &http.Client{
 	Transport: &http.Transport{
 		MaxIdleConnsPerHost: 10,
+		Proxy:               http.ProxyFromEnvironment,
 	},
 	Timeout: defaultClientTimeout,
 }
@@ -34,6 +35,7 @@ var defaultInsecureHTTPClient = &http.Client{
 	Timeout: defaultClientTimeout,
 	Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		Proxy:           http.ProxyFromEnvironment,
 	},
 }
 


### PR DESCRIPTION
<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->

I use Glance in a network-restricted environment, and I need an HTTP proxy to connect to third-party services.  
This change adds support for the http_proxy and https_proxy environment variables in the native Go way.

Before the change:
```
2025/05/15 06:08:23 ERROR Failed to fetch market data symbol=BTC-USD error="Get \"https://query1.finance.yahoo.com/v8/finance/chart/BTC-USD?range=1mo&interval=1d\": dial tcp: lookup query1.finance.yahoo.com on 127.0.0.11:53: server misbehaving"
```