### PR TITLE
Add Anchors to Links to Configuration Documentation within README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><em>What if you could see everything at a...</em></p>
 <h1 align="center">Glance</h1>
-<p align="center"><a href="#installation">Install</a> • <a href="docs/configuration.md">Configuration</a> • <a href="https://discord.com/invite/7KQ7Xa9kJd">Discord</a> • <a href="https://github.com/sponsors/glanceapp">Sponsor</a></p>
+<p align="center"><a href="#installation">Install</a> • <a href="docs/configuration.md#configuring-glance">Configuration</a> • <a href="https://discord.com/invite/7KQ7Xa9kJd">Discord</a> • <a href="https://github.com/sponsors/glanceapp">Sponsor</a></p>
 <p align="center"><a href="https://github.com/glanceapp/community-widgets">Community widgets</a> • <a href="docs/preconfigured-pages.md">Preconfigured pages</a> • <a href="docs/themes.md">Themes</a></p>
 
 ![](docs/images/readme-main-image.png)
@@ -17,7 +17,7 @@
 * Docker containers status
 * Server stats
 * Custom widgets
-* [and many more...](docs/configuration.md)
+- [and many more...](docs/configuration.md#configuring-glance)
 
 ### Fast and lightweight
 * Low memory usage
@@ -46,8 +46,8 @@ Easily create your own theme by tweaking a few numbers or choose from one of the
 <br>
 
 ## Configuration
-Configuration is done through YAML files, to learn more about how the layout works, how to add more pages and how to configure widgets, visit the [configuration documentation](docs/configuration.md).
 
+Configuration is done through YAML files, to learn more about how the layout works, how to add more pages and how to configure widgets, visit the [configuration documentation](docs/configuration.md#configuring-glance).
 <details>
 <summary><strong>Preview example configuration file</strong></summary>
 <br>


### PR DESCRIPTION
This is a really small, nitpick-level detail that just makes the README function a bit more intuitively.

### What is this?

I added an anchor to the README's links to the configuration documentation (`/docs/configuration.md`).

```diff
diff --git a/README.md b/README.md
index ca16c49..4ed527a 100644
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 * Docker containers status
 * Server stats
 * Custom widgets
-* [and many more...](docs/configuration.md)
+- [and many more...](docs/configuration.md#configuring-glance)
```

### Why does this matter?

When you click any of the current 3 links to the configuration README, the first thing you see is the _Table of Contents_, which uses anchors to navigate.

If you click on a link, e.g., 'Docker Containers', the current tab's URL will change from `https://github.com/Xevion/glance/blob/main/docs/configuration.md` to `https://github.com/Xevion/glance/blob/main/docs/configuration.md#docker-containers`.

But if you try to navigate backwards, e.g. by clicking the back button, or pressing a keyboard shortcut (`Alt+Left` in most browsers), the page won't change at all. Your URL will change back to one without an anchor, but that's it.

My small change makes sure that the page **starts** with an appropriate anchor, one at the very top of the page. With my page, navigating backwards will send you back to the top of the page, where the table of contents is.

This is how most users intuitively expect the README to function, hence my pull request.