### PR TITLE
Allow customizing the HTTP options in a more flexible way

### DIFF
--- a/internal/glance/widget-rss.go
+++ b/internal/glance/widget-rss.go
@@ -38,6 +38,7 @@ type rssWidget struct {
 	CollapseAfter    int              `yaml:"collapse-after"`
 	SingleLineTitles bool             `yaml:"single-line-titles"`
 	PreserveOrder    bool             `yaml:"preserve-order"`
+	Http             httpOptionsField `yaml:"http"`
 
 	Items          rssFeedItemList `yaml:"-"`
 	NoItemsMessage string          `yaml:"-"`
@@ -195,6 +196,11 @@ func (widget *rssWidget) fetchItemsFromFeedTask(request rssFeedRequest) ([]rssFe
 		return nil, err
 	}
 
+	client := defaultHTTPClient
+	if widget.Http.client != nil {
+		client = widget.Http.client
+	}
+
 	req.Header.Add("User-Agent", glanceUserAgentString)
 
 	widget.cachedFeedsMutex.Lock()
@@ -213,7 +219,7 @@ func (widget *rssWidget) fetchItemsFromFeedTask(request rssFeedRequest) ([]rssFe
 		req.Header.Set(key, value)
 	}
 
-	resp, err := defaultHTTPClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The goal was to resolve the issue here https://github.com/glanceapp/glance/issues/562 but it appears there are a few of the same issue floating around.

This adds an HTTP configuration similar to the Proxy one that was added but is more flexible in that you can adjust things without requiring a proxy.

Part of me thinks this should be a global setting but I only really have a few spots where I ever need to adjust the maximum.