### PR TITLE
Fix text-truncate or related formatting

### DIFF
--- a/internal/glance/static/js/page.js
+++ b/internal/glance/static/js/page.js
@@ -661,7 +661,7 @@ function setupTruncatedElementTitles() {
 
     for (let i = 0; i < elements.length; i++) {
         const element = elements[i];
-        if (element.getAttribute("title") === null) element.title = element.textContent.trim();
+        if (element.getAttribute("title") === null) element.title = element.innerText;
     }
 }
 

--- a/internal/glance/static/js/page.js
+++ b/internal/glance/static/js/page.js
@@ -661,7 +661,7 @@ function setupTruncatedElementTitles() {
 
     for (let i = 0; i < elements.length; i++) {
         const element = elements[i];
-        if (element.getAttribute("title") === null) element.title = element.textContent;
+        if (element.getAttribute("title") === null) element.title = element.textContent.trim();
     }
 }
 


### PR DESCRIPTION
<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->

This addresses the weird formatting that's happening when using `text-truncate`, `single-line-titles` and similar classes
![image](https://github.com/user-attachments/assets/4a43aabb-b87e-4e24-ad6e-5ec6c25cda20)
![image](https://github.com/user-attachments/assets/c99f1447-4ea3-4296-a926-8cce00a94d84)

Test config:
```yml
- type: html
  title: Playground
  source: |
    <div class="text-truncate">
      I am a sample text for text-truncate that will truncate a long text
    </div>
    <div>-----</div>
    <div class="text-truncate-2-lines">
      I too am a sample text to text text-truncate-2-lines
    </div>
    <div class="text-truncate"></div>
```

Edit: 
I feel like doing `.replace(/\s+/g, ' ').trim()` to also remove new lines before the trim would be better, but maybe that's just me.