### PR TITLE
Correct docs for Go's `text/html` built-in template functions

### DIFF
--- a/docs/custom-api.md
+++ b/docs/custom-api.md
@@ -464,9 +464,9 @@ The following helper functions provided by Go's `text/template` are available:
 - `eq(a, b any) bool`: Compares two values for equality.
 - `ne(a, b any) bool`: Compares two values for inequality.
 - `lt(a, b any) bool`: Compares two values for less than.
-- `lte(a, b any) bool`: Compares two values for less than or equal to.
+- `le(a, b any) bool`: Compares two values for less than or equal to.
 - `gt(a, b any) bool`: Compares two values for greater than.
-- `gte(a, b any) bool`: Compares two values for greater than or equal to.
+- `ge(a, b any) bool`: Compares two values for greater than or equal to.
 - `and(args ...bool) bool`: Returns true if **all** arguments are true; accepts two or more boolean values.
 - `or(args ...bool) bool`: Returns true if **any** argument is true; accepts two or more boolean values.
 - `not(a bool) bool`: Returns the opposite of the value.


### PR DESCRIPTION
Source: https://pkg.go.dev/text/template#hdr-Functions

The comparison functions the greater-than-or-equal-to and less-than-or-equal-to are `ge` and `le`, not `gte` and `lte`. I got an error rendering my template before I realized this.

<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->
