### PR TITLE
setupTodos using incorrect logic and skipping to-do item.

### DIFF
--- a/internal/glance/static/js/page.js
+++ b/internal/glance/static/js/page.js
@@ -643,13 +643,14 @@ async function setupCalendars() {
 }
 
 async function setupTodos() {
-    const elems = document.getElementsByClassName("todo");
+    var elems = Array.prototype.slice.call(document.getElementsByClassName("todo"));
     if (elems.length == 0) return;
 
     const todo = await import ('./todo.js');
 
-    for (let i = 0; i < elems.length; i++)
+    for (let i = 0; i < elems.length; i++){
         todo.default(elems[i]);
+    }
 }
 
 function setupTruncatedElementTitles() {


### PR DESCRIPTION
After looking over #703, I realized that `todo.default(elems[i])` in [page.js](https://github.com/glanceapp/glance/blob/b94647efc9145beb3a47368b30f633cc8e94acc2/internal/glance/static/js/page.js#L652C9-L652C32) was overwriting elements while still reading over them in the loop. This causes a Todo element to "disappear" as it takes the position of the overwritten element and being skipped in the iteration.

The fix is to create a copy of the element array so that it is maintained while changes are being made to the document.
