### PR TITLE
Support regular background widget refresh

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -257,6 +257,8 @@ Server configuration is done through a top level `server` property. Example:
 server:
   port: 8080
   assets-path: /home/user/glance-assets
+  background-refresh-enabled: true
+  background-refresh-interval: 15m
 ```
 
 ### Properties
@@ -268,6 +270,8 @@ server:
 | proxied | boolean | no | false |
 | base-url | string | no | |
 | assets-path | string | no |  |
+| background-refresh-enabled | boolean | no | false |
+| background-refresh-interval | duration | no | 15m |
 
 #### `host`
 The address which the server will listen on. Setting it to `localhost` means that only the machine that the server is running on will be able to access the dashboard. By default it will listen on all interfaces.
@@ -287,6 +291,12 @@ The base URL that Glance is hosted under. No need to specify this unless you're 
 
 #### `assets-path`
 The path to a directory that will be served by the server under the `/assets/` path. This is handy for widgets like the Monitor where you have to specify an icon URL and you want to self host all the icons rather than pointing to an external source.
+
+#### `background-refresh-enabled`
+Whether to enable automatic background refresh of widget data. When enabled, Glance will periodically update all widgets that have outdated cached data in the background, ensuring that your dashboards always show fresh information even when no one is actively viewing them. This significantly improves page load times since widget data is already current when pages are accessed.
+
+#### `background-refresh-interval`
+How often to run the background refresh process. Accepts duration values like `5m` (5 minutes), `30s` (30 seconds), `1h` (1 hour), etc. Shorter intervals mean more up-to-date data but may increase resource usage and API calls. Longer intervals reduce resource usage but may result in slightly stale data between refresh cycles.
 
 > [!IMPORTANT]
 >

--- a/internal/glance/config.go
+++ b/internal/glance/config.go
@@ -29,11 +29,13 @@ const (
 
 type config struct {
 	Server struct {
-		Host       string `yaml:"host"`
-		Port       uint16 `yaml:"port"`
-		Proxied    bool   `yaml:"proxied"`
-		AssetsPath string `yaml:"assets-path"`
-		BaseURL    string `yaml:"base-url"`
+		Host                     string        `yaml:"host"`
+		Port                     uint16        `yaml:"port"`
+		Proxied                  bool          `yaml:"proxied"`
+		AssetsPath               string        `yaml:"assets-path"`
+		BaseURL                  string        `yaml:"base-url"`
+		BackgroundRefreshEnabled bool          `yaml:"background-refresh-enabled"`
+		BackgroundRefreshInterval time.Duration `yaml:"background-refresh-interval"`
 	} `yaml:"server"`
 
 	Auth struct {
@@ -99,6 +101,8 @@ func newConfigFromYAML(contents []byte) (*config, error) {
 
 	config := &config{}
 	config.Server.Port = 8080
+	config.Server.BackgroundRefreshEnabled = false
+	config.Server.BackgroundRefreshInterval = 15 * time.Minute
 
 	err = yaml.Unmarshal(contents, config)
 	if err != nil {

--- a/internal/glance/widget.go
+++ b/internal/glance/widget.go
@@ -131,6 +131,7 @@ type widget interface {
 
 	initialize() error
 	requiresUpdate(*time.Time) bool
+	requiresUpdateWithin(*time.Time, time.Duration) bool
 	setProviders(*widgetProviders)
 	update(context.Context)
 	setID(uint64)
@@ -180,6 +181,21 @@ func (w *widgetBase) requiresUpdate(now *time.Time) bool {
 	}
 
 	return now.After(w.nextUpdate)
+}
+
+// requiresUpdateWithin checks if the widget will require an update within the given duration
+func (w *widgetBase) requiresUpdateWithin(now *time.Time, duration time.Duration) bool {
+	if w.cacheType == cacheTypeInfinite {
+		return false
+	}
+
+	if w.nextUpdate.IsZero() {
+		return true
+	}
+
+	// Check if the widget will be outdated before now + duration
+	futureTime := now.Add(duration)
+	return futureTime.After(w.nextUpdate) || now.After(w.nextUpdate)
 }
 
 func (w *widgetBase) IsWIP() bool {


### PR DESCRIPTION
I, like probably many others, am using Glance as a home page and new tab page. The search bar is where I start most of my navigation (hence #706), but I am frequently waiting for widgets to refresh before anything shows up. This PR aims to address some of these issues and ensure page loads are speedy every time.

- Predictive Widget Refresh
  - Updates widgets that are outdated OR will become outdated before the next refresh cycle
  - Prevents widgets from being stale when users visit pages
  - Example: With 15min refresh interval, a widget expiring in 5min gets updated proactively

- Configurable
  - background-refresh-enabled (default: false) - opt-in
  - background-refresh-interval (default: 15m) - customizable refresh frequency

```yaml
  server:
    background-refresh-enabled: true
    background-refresh-interval: 10m
```