### PR TITLE
truncate reddit vertical list at 3 lines

### DIFF
--- a/internal/glance/templates/forum-posts.html
+++ b/internal/glance/templates/forum-posts.html
@@ -23,7 +23,7 @@
             {{- end }}
             {{- end }}
             <div class="grow min-width-0">
-                <a href="{{ .DiscussionUrl | safeURL }}" class="size-title-dynamic color-primary-if-not-visited" target="_blank" rel="noreferrer">{{ .Title }}</a>
+                <a href="{{ .DiscussionUrl | safeURL }}" class="size-title-dynamic color-primary-if-not-visited text-truncate-3-lines" target="_blank" rel="noreferrer">{{ .Title }}</a>
                 {{- if .Tags }}
                 <div class="inline-block forum-post-tags-container">
                     <ul class="attachments">


### PR DESCRIPTION
Reddit post titles can get pretty long. Other reddit widgets have text truncated, this is simply adding it to the vertical list widget as well to help keep page layout relatively consistent.