### PR TITLE
Fix DNS summary tap highlight

### DIFF
--- a/internal/glance/static/css/site.css
+++ b/internal/glance/static/css/site.css
@@ -61,6 +61,10 @@ button {
     width: 10px;
 }
 
+*:active {
+    -webkit-tap-highlight-color: transparent;
+}
+
 *:focus-visible {
     outline: 2px solid var(--color-primary);
     outline-offset: 0.1rem;

--- a/internal/glance/static/css/utils.css
+++ b/internal/glance/static/css/utils.css
@@ -53,10 +53,6 @@
     display: none;
 }
 
-.summary:active {
-    -webkit-tap-highlight-color: transparent;
-}
-
 .details[open] .summary {
     margin-bottom: .8rem;
 }

--- a/internal/glance/static/css/utils.css
+++ b/internal/glance/static/css/utils.css
@@ -53,6 +53,10 @@
     display: none;
 }
 
+.summary:active {
+    -webkit-tap-highlight-color: transparent;
+}
+
 .details[open] .summary {
     margin-bottom: .8rem;
 }


### PR DESCRIPTION
<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->
Chrome based mobile view with the summary tag has a tap highlight that does not cover the entire area.
![Screenshot_20250617_185913](https://github.com/user-attachments/assets/8bae6db7-cc95-4eb9-bf08-badb79eb0a64)

<details>
<summary>Personally, I'd apply this to a system level.</summary>

```css
*:active {
    -webkit-tap-highlight-color: transparent;
}
```
</details>