### PR TITLE
Added Object helper for custom-api

### DIFF
--- a/docs/custom-api.md
+++ b/docs/custom-api.md
@@ -445,10 +445,8 @@ The following functions are available on the `JSON` object:
 - `Float(key string) float`: Returns the value of the key as a float.
 - `Bool(key string) bool`: Returns the value of the key as a boolean.
 - `Array(key string) []JSON`: Returns the value of the key as an array of `JSON` objects.
-- `Object(key string)`: Returns the value of the key as a list of properties.
-  - `.Key`: the property name
-  - `.Value`: the property value
 - `Exists(key string) bool`: Returns true if the key exists in the JSON object.
+- `Entries(key string)`: Returns an iterator that allows you to loop through each property of the object. Example: `{{ range $key, $value := .JSON.Entries "user" }}`. This will yield pairs of key and value, where `$key` is a string and `$value` is a `JSON` object.
 
 The following functions are available on the `Options` object:
 

--- a/internal/glance/widget-custom-api.go
+++ b/internal/glance/widget-custom-api.go
@@ -358,11 +358,6 @@ type decoratedGJSONResult struct {
 	gjson.Result
 }
 
-type ObjectProperty struct {
-	Key   string
-	Value decoratedGJSONResult
-}
-
 func gJsonResultArrayToDecoratedResultArray(results []gjson.Result) []decoratedGJSONResult {
 	decoratedResults := make([]decoratedGJSONResult, len(results))
 


### PR DESCRIPTION
<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->

There are API's that list items as Objects instead of Array similar to this discussion https://github.com/glanceapp/glance/discussions/742, Mostly RPC endpoints

This adds a helper function `Object` a bit similar to `Array` except this has `.Key` and `.Value` helper itself.

Sample API data:
```json
{
    "object": {
      "key1": "value1",
      "key2": "value2",
      "key3": {
        "test1": "v1",
        "test2": "v2"
      },
    }
}
```

Config:
```yml
- type: custom-api
  url: http://webserver.local/sample-object
  cache: 1s
  template: |
    <div>Objects</div>
    {{ range .JSON.Object "object" }}
      <div>{{ .Key }}: {{ .Value.String "" }} | {{ .Value.String "test1" }}</div>
    {{ end }}
    <br>
    <div>Length: {{ len (.JSON.Object "object") }}</div>
```

Result:
![Screenshot_20250623_204314](https://github.com/user-attachments/assets/a253fd3b-a994-4a62-a244-e0d0bd06427d)

<sub>*Unless there's already a way? couldn't find one.*</sub>
