### PR TITLE
Fix bookmark link arrow wrap

### DIFF
--- a/internal/glance/static/css/widget-bookmarks.css
+++ b/internal/glance/static/css/widget-bookmarks.css
@@ -6,6 +6,10 @@
     color: var(--bookmarks-group-color);
 }
 
+.bookmarks-link {
+    white-space: nowrap;
+}
+
 .bookmarks-link:not(.bookmarks-link-no-arrow)::after {
     content: '↗' / "";
     margin-left: 0.5em;


### PR DESCRIPTION
<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->

This fixes an issue where the arrow of a bookmark link goes down.

<img width="314" height="91" alt="image" src="https://github.com/user-attachments/assets/b1827493-059d-443d-ae0e-e43bfb556ed6" />
