### PR TITLE
Add date threshold for videos widget

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -864,16 +864,17 @@ Preview:
 ![](images/videos-widget-preview.png)
 
 #### Properties
-| Name | Type | Required | Default |
-| ---- | ---- | -------- | ------- |
-| channels | array | yes | |
-| playlists | array | no | |
-| limit | integer | no | 25 |
-| style | string | no | horizontal-cards |
-| collapse-after | integer | no | 7 |
+| Name                | Type    | Required | Default |
+|---------------------|---------| -------- | ------- |
+| channels            | array   | yes | |
+| playlists           | array   | no | |
+| limit               | integer | no | 25 |
+| style               | string  | no | horizontal-cards |
+| collapse-after      | integer | no | 7 |
 | collapse-after-rows | integer | no | 4 |
-| include-shorts | boolean | no | false |
-| video-url-template | string | no | https://www.youtube.com/watch?v={VIDEO-ID} |
+| include-shorts      | boolean | no | false |
+| publish-threshold   | int | no | 0 |
+| video-url-template  | string  | no | https://www.youtube.com/watch?v={VIDEO-ID} |
 
 ##### `channels`
 A list of channels IDs.
@@ -921,6 +922,9 @@ Preview of `vertical-list`:
 Preview of `grid-cards`:
 
 ![](images/videos-widget-grid-cards-preview.png)
+
+##### `publish-threshold`
+Used to display only videos published in the last number of days mentioned through the provided value. 
 
 ##### `video-url-template`
 Used to replace the default link for videos. Useful when you're running your own YouTube front-end. Example:

--- a/internal/glance/widget-videos.go
+++ b/internal/glance/widget-videos.go
@@ -192,11 +192,11 @@ func fetchYoutubeChannelUploads(channelOrPlaylistIDs []string, videoUrlTemplate 
 				}
 			}
 
-            published := parseYoutubeFeedTime(v.Published)
-            dateThreshold := time.Now().AddDate(0, 0, -publishThreshold)
-            if publishThreshold > 0 && published.Before(dateThreshold) {
-                continue
-            }
+			published := parseYoutubeFeedTime(v.Published)
+			dateThreshold := time.Now().AddDate(0, 0, -publishThreshold)
+			if publishThreshold > 0 && published.Before(dateThreshold) {
+				continue
+			}
 
 			videos = append(videos, video{
 				ThumbnailUrl: v.Group.Thumbnail.Url,


### PR DESCRIPTION
I would like to only display videos that were published in the last `n` days rather than have all older videos. For me, this comes in handy when aggregating multiple channels that publish videos in certain time periods and exclude what I don't really need anymore to have a clean, tidy interface - when there is nothing to do, there is nothing to do.

Since I had made the changes, I thought that other people might want this as well.

If this gets approved, I would like to have someone test the feature as well as this is my first time dwelving in Go lang.

Thanks! :)