### PR TITLE
Support passwordless Pi-hole 6+

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2359,7 +2359,7 @@ Only required when using AdGuard Home. The username used to log into the admin d
 ##### `password`
 Required when using AdGuard Home, where the password is the one used to log into the admin dashboard.
 
-Also required when using Pi-hole major version 6 and above, where the password is the one used to log into the admin dashboard or the application password, which can be found in `Settings -> Web Interface / API -> Configure app password`.
+For Pi-hole version 6+, this field is required if you have set a password to log into Pi-hole. You can either use the password you use to log into the admin dashboard or the application password, which can be found in `Settings -> Web Interface / API -> Configure app password`.
 
 ##### `token`
 Required when using Pi-hole major version 5 or earlier. The API token which can be found in `Settings -> API -> Show API token`.

--- a/internal/glance/widget-dns-stats.go
+++ b/internal/glance/widget-dns-stats.go
@@ -429,22 +429,24 @@ func fetchPiholeStats(
 		return nil
 	}
 
-	if sessionID == "" {
-		if err := fetchNewSessionID(); err != nil {
-			slog.Error("Failed to fetch Pihole v6 session ID", "error", err)
-			return nil, "", fmt.Errorf("fetching session ID: %v", err)
-		}
-	} else {
-		isValid, err := checkPiholeSessionIDIsValid(instanceURL, client, sessionID)
-		if err != nil {
-			slog.Error("Failed to check Pihole v6 session ID validity", "error", err)
-			return nil, "", fmt.Errorf("checking session ID: %v", err)
-		}
-
-		if !isValid {
+	if password != "" {
+		if sessionID == "" {
 			if err := fetchNewSessionID(); err != nil {
-				slog.Error("Failed to renew Pihole v6 session ID", "error", err)
-				return nil, "", fmt.Errorf("renewing session ID: %v", err)
+				slog.Error("Failed to fetch Pihole v6 session ID", "error", err)
+				return nil, "", fmt.Errorf("fetching session ID: %v", err)
+			}
+		} else {
+			isValid, err := checkPiholeSessionIDIsValid(instanceURL, client, sessionID)
+			if err != nil {
+				slog.Error("Failed to check Pihole v6 session ID validity", "error", err)
+				return nil, "", fmt.Errorf("checking session ID: %v", err)
+			}
+
+			if !isValid {
+				if err := fetchNewSessionID(); err != nil {
+					slog.Error("Failed to renew Pihole v6 session ID", "error", err)
+					return nil, "", fmt.Errorf("renewing session ID: %v", err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This commit support Pi-hole v6+ instances where no password is set. In this case, the session id endpoint should not be called since it returns `no password set`.