### PR TITLE
Added icon support for compact

### DIFF
--- a/internal/glance/templates/monitor-compact.html
+++ b/internal/glance/templates/monitor-compact.html
@@ -2,7 +2,7 @@
 
 {{ define "widget-content" }}
 {{ if not (and .ShowFailingOnly (not .HasFailing)) }}
-<ul class="dynamic-columns list-gap-8">
+<ul class="dynamic-columns list-gap-10">
     {{ range .Sites }}
     {{ if and $.ShowFailingOnly (eq .StatusStyle "ok" ) }}{{ continue }}{{ end }}
     <div class="flex items-center gap-12">
@@ -21,6 +21,9 @@
 {{ end }}
 
 {{ define "site" }}
+{{ if .Icon.URL }}
+{{ .Icon.ElemWithClass "square-20" }}
+{{ end }}
 <a class="size-title-dynamic color-highlight text-truncate block grow" href="{{ .URL | safeURL }}" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer">{{ .Title }}</a>
 {{ if not .Status.TimedOut }}<div>{{ .Status.ResponseTime.Milliseconds | formatNumber }}ms</div>{{ end }}
 {{ if eq .StatusStyle "ok" }}


### PR DESCRIPTION
<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->
<details>
<summary>Example Configuration</summary>

```yml
- size: full
  widgets:
    - type: monitor
      title: Monitor
      sites:
        - title: Home Assistant
          url: https://hass.${DOMAIN}
          icon: ${DASHBOARD_ICONS}/svg/home-assistant.svg
        - title: Node-Red
          url: https://node-red.${DOMAIN}
          check-url: https://node-red.${DOMAIN}/diagnostics
          icon: ${DASHBOARD_ICONS}/svg/node-red.svg
        - title: Dawarich
          url: https://timeline.${DOMAIN}
          icon: ${DASHBOARD_ICONS}/svg/dawarich.svg
    - type: monitor
      title: Monitor Compact with Icons
      style: compact
      sites:
        - title: Home Assistant
          url: https://hass.${DOMAIN}
          icon: ${DASHBOARD_ICONS}/svg/home-assistant.svg
        - title: Node-Red
          url: https://node-red.${DOMAIN}
          check-url: https://node-red.${DOMAIN}/diagnostics
          icon: ${DASHBOARD_ICONS}/svg/node-red.svg
        - title: Dawarich
          url: https://timeline.${DOMAIN}
          icon: ${DASHBOARD_ICONS}/svg/dawarich.svg
    - type: monitor
      title: Monitor Compact without Icons
      style: compact
      sites:
        - title: Home Assistant
          url: https://hass.${DOMAIN}
        - title: Node-Red
          url: https://node-red.${DOMAIN}
          check-url: https://node-red.${DOMAIN}/diagnostics
        - title: Dawarich
          url: https://timeline.${DOMAIN}
```

</details>

## Screenshots
<img width="599" height="627" alt="image" src="https://github.com/user-attachments/assets/84b0e305-d99c-4c72-8b85-4aa50ff5d6dc" />

<img width="954" height="411" alt="image" src="https://github.com/user-attachments/assets/accc122f-2a8c-4a4f-87ef-e597ecea398c" />
