### PR TITLE
feat: Per-page user access control feature

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -283,6 +283,56 @@ server:
 
 When set to `true`, Glance will use the `X-Forwarded-For` header to determine the original IP address of the request, so make sure that your reverse proxy is correctly configured to send that header.
 
+### Restricting pages to specific users
+
+You can restrict access to specific pages by using the `allowed-users` property on a page. When this property is set, only the listed users will be able to access that page. Users not in the list will receive a 403 Forbidden error when attempting to access the page. Example:
+
+```yaml
+auth:
+  secret-key: # generated secret key
+  users:
+    admin:
+      password: admin123
+    john:
+      password: john123
+    jane:
+      password: jane123
+
+pages:
+  - name: Home
+    # No allowed-users property means all authenticated users can access this page
+    columns:
+      - size: full
+        widgets:
+          - type: rss
+
+  - name: Admin
+    allowed-users:
+      - admin
+    columns:
+      - size: full
+        widgets:
+          - type: monitor
+
+  - name: Work
+    allowed-users:
+      - john
+      - jane
+    columns:
+      - size: full
+        widgets:
+          - type: calendar
+```
+
+In this example:
+- The "Home" page is accessible by all authenticated users (admin, john, and jane)
+- The "Admin" page is only accessible by the `admin` user
+- The "Work" page is accessible by both `john` and `jane`
+
+> [!NOTE]
+>
+> If a page does not have the `allowed-users` property set, all authenticated users will be able to access it. If you want to restrict access to all pages, you must explicitly set the `allowed-users` property on each page.
+
 ## Server
 Server configuration is done through a top level `server` property. Example:
 
@@ -560,6 +610,7 @@ pages:
 | center-vertically | boolean | no | false |
 | hide-desktop-navigation | boolean | no | false |
 | show-mobile-header | boolean | no | false |
+| allowed-users | array | no | |
 | head-widgets | array | no | |
 | columns | array | yes | |
 
@@ -597,6 +648,9 @@ Whether to show a header displaying the name of the page on mobile. The header p
 Preview:
 
 ![](images/mobile-header-preview.png)
+
+#### `allowed-users`
+A list of usernames that are allowed to access this page. When this property is set, only the listed users will be able to view the page. Users not in the list will receive a 403 Forbidden error. If this property is not added, all authenticated users will be able to access the page. See the [Restricting pages to specific users](#restricting-pages-to-specific-users) section for more details and examples.
 
 #### `head-widgets`
 

--- a/internal/glance/config.go
+++ b/internal/glance/config.go
@@ -75,14 +75,15 @@ type user struct {
 }
 
 type page struct {
-	Title                  string  `yaml:"name"`
-	Slug                   string  `yaml:"slug"`
-	Width                  string  `yaml:"width"`
-	DesktopNavigationWidth string  `yaml:"desktop-navigation-width"`
-	ShowMobileHeader       bool    `yaml:"show-mobile-header"`
-	HideDesktopNavigation  bool    `yaml:"hide-desktop-navigation"`
-	CenterVertically       bool    `yaml:"center-vertically"`
-	HeadWidgets            widgets `yaml:"head-widgets"`
+	Title                  string   `yaml:"name"`
+	Slug                   string   `yaml:"slug"`
+	Width                  string   `yaml:"width"`
+	DesktopNavigationWidth string   `yaml:"desktop-navigation-width"`
+	ShowMobileHeader       bool     `yaml:"show-mobile-header"`
+	HideDesktopNavigation  bool     `yaml:"hide-desktop-navigation"`
+	CenterVertically       bool     `yaml:"center-vertically"`
+	AllowedUsers           []string `yaml:"allowed-users"`
+	HeadWidgets            widgets  `yaml:"head-widgets"`
 	Columns                []struct {
 		Size    string  `yaml:"size"`
 		Widgets widgets `yaml:"widgets"`

--- a/internal/glance/static/css/mobile.css
+++ b/internal/glance/static/css/mobile.css
@@ -59,6 +59,16 @@
         background-color: var(--color-widget-background-highlight);
     }
 
+    .mobile-username-container {
+        cursor: default;
+        pointer-events: none;
+    }
+
+    .mobile-username {
+        font-weight: 600;
+        color: var(--color-primary);
+    }
+
     .mobile-navigation:has(.mobile-navigation-page-links-input:checked) .hamburger-icon {
         --spacing: 7px;
         color: var(--color-primary);

--- a/internal/glance/static/css/site.css
+++ b/internal/glance/static/css/site.css
@@ -325,6 +325,13 @@ kbd:active {
     color: var(--color-text-highlight);
 }
 
+.username-display {
+    margin-right: 1rem;
+    font-size: var(--font-size-h3);
+    color: var(--color-primary);
+    font-weight: 600;
+}
+
 .logout-button {
     width: 2rem;
     height: 2rem;

--- a/internal/glance/templates/page.html
+++ b/internal/glance/templates/page.html
@@ -7,7 +7,7 @@
 {{ end }}
 
 {{ define "navigation-links" }}
-{{ range .App.Config.Pages }}
+{{ range $.AccessiblePages }}
 <a href="{{ $.App.Config.Server.BaseURL }}/{{ .Slug }}" class="nav-item{{ if eq .Slug $.Page.Slug }} nav-item-current{{ end }}"{{ if eq .Slug $.Page.Slug }} aria-current="page"{{ end }}><div class="nav-item-text">{{ .Title }}</div></a>
 {{ end }}
 {{ end }}
@@ -44,6 +44,7 @@
             </div>
             {{ end }}
             {{- if .App.RequiresAuth }}
+            <div class="username-display self-center">{{ .Request.Username }}</div>
             <a class="block self-center" href="{{ .App.Config.Server.BaseURL }}/logout" title="Logout">
                 <svg class="logout-button" stroke="var(--color-text-subdue)" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" />
@@ -93,6 +94,10 @@
             {{ end }}
 
             {{ if .App.RequiresAuth }}
+            <div class="flex justify-between items-center mobile-username-container">
+                <div class="size-h3">Logged in as:</div>
+                <div class="mobile-username">{{ .Request.Username }}</div>
+            </div>
             <a href="{{ .App.Config.Server.BaseURL }}/logout" class="flex justify-between items-center">
                 <div class="size-h3">Logout</div>
                 <svg class="ui-icon" stroke="var(--color-text-subdue)" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5">


### PR DESCRIPTION
Solves https://github.com/glanceapp/glance/issues/694 and https://github.com/glanceapp/glance/issues/856.
User-based page access control to the application, allowing pages to specify which users are permitted to view them. It also updates navigation and UI elements to reflect the authenticated user's identity and restricts navigation links to only those pages the user can access.
- Add functions to retrieve username from request and check page access.
- Update page struct to include allowed users.
- Modify template data to include accessible pages for the user.
- Enhance HTML templates to display logged-in username and restrict access to pages based on user permissions.
- Introduce new CSS styles for username display in mobile and site views.

Usage:
```
pages:
  - name: Private
    allowed-users:
      - home
      - work
    columns: ...
```
Note: This is an optional field. If this property is not added then the page is available to all logged-in users. 

Example: 
<img width="1605" height="68" alt="image" src="https://github.com/user-attachments/assets/e604b853-24e3-4846-a9c5-6f648d532b66" />

<img width="1588" height="70" alt="image" src="https://github.com/user-attachments/assets/c0507f23-46db-4ab4-9501-e379f03a15dd" />

`glance.yml`:
```
server:
  assets-path: /app/assets

auth:
  secret-key: ....
  users:
    home:
      password-hash: ....
    work:
      password-hash: ....

theme:
  custom-css-file: /assets/user.css

pages:
  - $include: home.yml
  - $include: admin.yml
  - $include: work.yml
  - $include: misc.yml
```

`home.yml`:
```
- name: Home
  columns:
    - ....
```

`admin.yml`:
```
- name: Admin
  allowed-users:
    - home
  columns:
    - ....
```

`work.yml`:
```
- name: Work
  allowed-users:
    - work
  columns:
    - ....
```

`misc.yml`:
```
- name: Misc
  allowed-users:
    - home
  columns:
    - ....
```