### PR TITLE
refactor: enhance Dockerfile with build args and optimized caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,22 @@
-FROM golang:1.24.3-alpine3.21 AS builder
+ARG GO_VERSION=1.24.3
+ARG ALPINE_VERSION=3.21
+
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
 
 WORKDIR /app
-COPY . /app
-RUN CGO_ENABLED=0 go build .
 
-FROM alpine:3.21
+RUN --mount=type=cache,target=/go/pkg/mod \
+  --mount=type=bind,source=go.mod,target=go.mod \
+  --mount=type=bind,source=go.sum,target=go.sum \
+  go mod download -x && go mod verify
+
+COPY . /app
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+  --mount=type=cache,target=/root/.cache \
+  CGO_ENABLED=0 go build .
+
+FROM alpine:${ALPINE_VERSION}
 
 WORKDIR /app
 COPY --from=builder /app/glance .


### PR DESCRIPTION
## What's changing
Refactored the Dockerfile to make it easier to maintain and faster to build.

## Why
- Build args let us update versions without editing the whole file
- Restored the mod cache layer so rebuilds are faster when you only change code
- Using the same Alpine version everywhere keeps things consistent

## What I did
- Added `GO_VERSION` and `ALPINE_VERSION` as build args
-  Re-added the `go mod download` step (better caching)
- Used the Alpine arg in the final stage instead of hardcoding
- Cleaned up spacing for readability
