### PR TITLE
feat: add ability to specify Host header in the Custom API widget

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1571,6 +1571,7 @@ Examples:
 | Name | Type | Required | Default |
 | ---- | ---- | -------- | ------- |
 | url | string | no | |
+| host | string | no | |
 | headers | key (string) & value (string) | no | |
 | method | string | no | GET |
 | body-type | string | no | json |
@@ -1594,6 +1595,9 @@ headers:
   x-api-key: your-api-key
   Accept: application/json
 ```
+
+##### `host`
+Optionally specify the `Host` header that will be sent with the request. This is useful when `url` points to a reverse proxy. Note that setting the `Host` header in `headers` has no effect.
 
 ##### `method`
 The HTTP method to use when making the request. Possible values are `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS` and `HEAD`.

--- a/docs/custom-api.md
+++ b/docs/custom-api.md
@@ -410,7 +410,7 @@ In some instances, you may need to make two consecutive API calls, where you use
     {{ $something.JSON.String "title" }}
 ```
 
-Here, `$theID` gets retrieved from the result of the first API call and used in the second API call. The `newRequest` function creates a new request, and the `getResponse` function executes it. You can also use `withParameter` and `withHeader` to optionally add parameters and headers to the request.
+Here, `$theID` gets retrieved from the result of the first API call and used in the second API call. The `newRequest` function creates a new request, and the `getResponse` function executes it. You can also use `withParameter` and `withHeader` to optionally add parameters and headers to the request. Note that `Host` header added using `withHeader` has no effect. You can use `withHost` to set the `Host` header. 
 
 If you need to make a request to a URL that requires dynamic parameters, you can omit the `url` property in the YAML and run the request entirely from within the template itself:
 

--- a/internal/glance/widget-custom-api.go
+++ b/internal/glance/widget-custom-api.go
@@ -30,6 +30,7 @@ type CustomAPIRequest struct {
 	URL                string               `yaml:"url"`
 	AllowInsecure      bool                 `yaml:"allow-insecure"`
 	Headers            map[string]string    `yaml:"headers"`
+	Host               string               `yaml:"host"`
 	Parameters         queryParametersField `yaml:"parameters"`
 	Method             string               `yaml:"method"`
 	BodyType           string               `yaml:"body-type"`
@@ -180,6 +181,10 @@ func (req *CustomAPIRequest) initialize() error {
 	httpReq, err := http.NewRequest(strings.ToUpper(req.Method), req.URL, req.bodyReader)
 	if err != nil {
 		return err
+	}
+
+	if req.Host != "" {
+		httpReq.Host = req.Host
 	}
 
 	if len(req.Parameters) > 0 {
@@ -688,6 +693,10 @@ var customAPITemplateFuncs = func() template.FuncMap {
 				req.Headers = make(map[string]string)
 			}
 			req.Headers[key] = value
+			return req
+		},
+		"withHost": func(value string, req *CustomAPIRequest) *CustomAPIRequest {
+			req.Host = value
 			return req
 		},
 		"withParameter": func(key, value string, req *CustomAPIRequest) *CustomAPIRequest {


### PR DESCRIPTION
Currently we cannot use reverse proxies in the Custom API as we cannot pass the `Host` header in the `headers` field. This is because `net/http` ignores the `Host` header and uses the `req.Host` field instead: https://github.com/golang/go/issues/7682.

This PR adds the support for it. The change is backward compatible. Tested with Traefik as the reverse proxy in my environment and confirmed that it's working.

Another option was to search for the `Host` header in the `headers` field and set that in `req.Host` but that would not be backward compatible.