### PR TITLE
Fix autofocus handling for search widget

### DIFF
--- a/internal/glance/static/js/page.js
+++ b/internal/glance/static/js/page.js
@@ -203,6 +203,14 @@ function setupSearchBoxes() {
         kbdElement.addEventListener("mousedown", () => {
             requestAnimationFrame(() => inputElement.focus());
         });
+
+        // Handle autofocus for dynamically loaded content
+        if (inputElement.hasAttribute("autofocus")) {
+            // Use requestAnimationFrame to ensure DOM is fully ready, especially for Firefox
+            requestAnimationFrame(() => {
+                inputElement.focus();
+            });
+        }
     }
 }
 


### PR DESCRIPTION
Adds logic to focus input elements with the autofocus attribute using requestAnimationFrame, ensuring proper behavior for dynamically loaded content (like the search widget) and improved compatibility with browsers like Firefox. Should fix #348 and any other autofocusing widget problems.

The problem is that the setupSearchBoxes() function runs after the page content is loaded, and it adds event listeners to the search input. However, the browser's autofocus behavior happens during initial page load, but since the content is loaded asynchronously and inserted via innerHTML, the autofocus attribute doesn't work as expected. I commited a fix that should solve this. It runs focus() on all elements with autofocus enabled after the widgets are added. Might not be the best solution but works for me on both Firefox and Chrome!
