### PR TITLE
Add optional descriptions to the Monitor widget

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1963,6 +1963,7 @@ Properties for each site:
 | check-url | string | no | |
 | error-url | string | no | |
 | icon | string | no | |
+| description | string | no | |
 | timeout | string | no | 3s |
 | allow-insecure | boolean | no | false |
 | same-tab | boolean | no | false |
@@ -1988,6 +1989,10 @@ If the monitored service returns an error, the user will be redirected here. If 
 `icon`
 
 See [Icons](#icons) for more information on how to specify icons.
+
+`description`
+
+A short description displayed below the title. Unset by default.
 
 `timeout`
 

--- a/internal/glance/static/css/utils.css
+++ b/internal/glance/static/css/utils.css
@@ -253,6 +253,14 @@ details[open] .summary::after {
     text-align: left;
 }
 
+.stretch-to-content {
+  min-width: 0;
+  display: flex;
+  flex-grow: 1;
+  flex-basis: 0%;
+  max-width: max-content;
+}
+
 .visited-indicator:not(:visited)::before, .visited-indicator:not(:visited)::after {
     color: var(--color-primary);
 }

--- a/internal/glance/templates/monitor.html
+++ b/internal/glance/templates/monitor.html
@@ -28,7 +28,9 @@
     <a class="size-h3 color-highlight text-truncate block" href="{{ .URL | safeURL }}" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer">{{ .Title }}</a>
     <ul class="list-horizontal-text">
         {{ if .Description }}
-        <li class="text-truncate">{{ .Description }}</li>
+        <div class="stretch-to-content">
+          <li class="text-truncate">{{ .Description }}</li>
+        </div>
         {{ end }}
         {{ if not .Status.Error }}
         <li title="{{ .Status.Code }}">{{ .StatusText }}</li>

--- a/internal/glance/templates/monitor.html
+++ b/internal/glance/templates/monitor.html
@@ -27,6 +27,9 @@
 <div class="grow min-width-0">
     <a class="size-h3 color-highlight text-truncate block" href="{{ .URL | safeURL }}" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer">{{ .Title }}</a>
     <ul class="list-horizontal-text">
+        {{ if .Description }}
+        <li class="text-truncate">{{ .Description }}</li>
+        {{ end }}
         {{ if not .Status.Error }}
         <li title="{{ .Status.Code }}">{{ .StatusText }}</li>
         <li>{{ .Status.ResponseTime.Milliseconds | formatNumber }}ms</li>

--- a/internal/glance/widget-monitor.go
+++ b/internal/glance/widget-monitor.go
@@ -23,6 +23,7 @@ type monitorWidget struct {
 		URL                string          `yaml:"-"`
 		ErrorURL           string          `yaml:"error-url"`
 		Title              string          `yaml:"title"`
+		Description        string          `yaml:"description"`
 		Icon               customIconField `yaml:"icon"`
 		SameTab            bool            `yaml:"same-tab"`
 		StatusText         string          `yaml:"-"`


### PR DESCRIPTION
Hello! Thanks for making Glance, I love it and it looks great! I really wanted descriptions under each Monitor service, in the same way as with Docker containers. So, this PR adds them.

I needed to wrap the text in a div and introduce a new CSS class to get truncation to work properly. Thanks!

## Example

<img width="886" height="255" alt="image" src="https://github.com/user-attachments/assets/af95bea7-8018-4837-8b64-43904c8390a8" />
