### PR TITLE
feat(rss): Extract rss article thumbnails from enclosures

### DIFF
--- a/internal/glance/widget-rss.go
+++ b/internal/glance/widget-rss.go
@@ -334,7 +334,7 @@ func (widget *rssWidget) fetchItemsFromFeedTask(request rssFeedRequest) ([]rssFe
 		} else {
 			rssItem.ChannelName = feed.Title
 		}
-		
+
 		if item.Image != nil {
 			rssItem.ImageURL = item.Image.URL
 		} else if url := findThumbnailInItemExtensions(item); url != "" {
@@ -405,11 +405,10 @@ func recursiveFindThumbnailInEnclosures(enclosures []*gofeed.Enclosure) string {
 	url := ""
 	
 	for _, enclosure := range enclosures {
-		switch enclosure.Type {
-			case "image/generic":
-				url = enclosure.URL
-			case "image/jpeg", "image/png", "image/gif":
-				return enclosure.URL
+		if url == "" && enclosure.Type == "image/generic" {
+			url = enclosure.URL
+		} else if enclosure.Type == "image/jpeg" || enclosure.Type == "image/png" || enclosure.Type == "image/gif" {
+			return enclosure.URL
 		}
 	}
 

--- a/internal/glance/widget-rss.go
+++ b/internal/glance/widget-rss.go
@@ -334,7 +334,7 @@ func (widget *rssWidget) fetchItemsFromFeedTask(request rssFeedRequest) ([]rssFe
 		} else {
 			rssItem.ChannelName = feed.Title
 		}
-
+		
 		if item.Image != nil {
 			rssItem.ImageURL = item.Image.URL
 		} else if url := findThumbnailInItemExtensions(item); url != "" {
@@ -388,13 +388,32 @@ func (widget *rssWidget) fetchItemsFromFeedTask(request rssFeedRequest) ([]rssFe
 }
 
 func findThumbnailInItemExtensions(item *gofeed.Item) string {
-	media, ok := item.Extensions["media"]
+    media, ok := item.Extensions["media"]
 
-	if !ok {
-		return ""
-	}
+    if !ok {
+		enclosures := item.Enclosures
+        if len(enclosures) == 0 {
+            return ""
+        }
+		return recursiveFindThumbnailInEnclosures(enclosures)
+    }
 
 	return recursiveFindThumbnailInExtensions(media)
+}
+
+func recursiveFindThumbnailInEnclosures(enclosures []*gofeed.Enclosure) string {
+	url := ""
+	
+	for _, enclosure := range enclosures {
+		switch enclosure.Type {
+			case "image/generic":
+				url = enclosure.URL
+			case "image/jpeg", "image/png", "image/gif":
+				return enclosure.URL
+		}
+	}
+
+	return url
 }
 
 func recursiveFindThumbnailInExtensions(extensions map[string][]gofeedext.Extension) string {


### PR DESCRIPTION
The current thumbnail extractor for the RSS widgets fails when its placed in an enclosure. This PR improves the coverage by:

1. If there is no media extension, check if there's 1 or more Enclosures
2. For each enclosure:
    1. If the enclosure has type image/generic, save the url 
    2. If the enclosure has type "image/jpeg", "image/png", "image/gif", immediately return that URL
3. If the loop finishes without returning, return the current url (will be the first generic image, or empty string)

Comments:
- Limited by choosing the first url found. Additional filtering could be added by getting the image dimensions at the cost of fetching each resource.
- I'm not super familiar with the specification for RSS/Atom so please let me know if theres any potential flaws with this approach.
- I'm primarily using RSS feeds exported from TTRSS which moves media from the source feed into enclosures.