### PR TITLE
feat: add raw-query option for search bangs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1205,6 +1205,7 @@ Example:
     - title: YouTube
       shortcut: "!yt"
       url: https://www.youtube.com/results?search_query={QUERY}
+      raw-query: false
 ```
 
 Preview:
@@ -1264,11 +1265,12 @@ What now? [Bangs](https://duckduckgo.com/bangs). They're shortcuts that allow yo
 ![](images/search-widget-bangs-preview.png)
 
 ##### Properties for each bang
-| Name | Type | Required |
-| ---- | ---- | -------- |
-| title | string | no |
-| shortcut | string | yes |
-| url | string | yes |
+| Name | Type | Required | Default |
+| ---- | ---- | -------- | ------- |
+| title | string | no | |
+| shortcut | string | yes | |
+| url | string | yes | |
+| raw-query | boolean | no | false |
 
 ###### `title`
 Optional title that will appear on the right side of the search bar when the query starts with the associated shortcut.
@@ -1290,6 +1292,43 @@ The URL of the search engine. Use `{QUERY}` to indicate where the query value ge
 url: https://www.reddit.com/search?q={QUERY}
 url: https://store.steampowered.com/search/?term={QUERY}
 url: https://www.amazon.com/s?k={QUERY}
+```
+
+###### `raw-query`
+Optional boolean that determines whether the query is inserted raw (without URL encoding) into the URL.
+
+> ```yaml
+> shortcut: "!gh"
+> url: https://github.com/{QUERY}
+> raw-query: false
+>
+> shortcut: "!ghr"
+> url: https://github.com/{QUERY}
+> raw-query: true
+>```
+
+Typing
+
+```
+!gh glanceapp/glance
+```
+
+would result in
+
+```
+https://github.com/glanceapp%2Fglance
+```
+
+whereas
+
+```
+!ghr glanceapp/glance
+```
+
+would result in
+
+```
+https://github.com/glanceapp/glance
 ```
 
 ### Group

--- a/internal/glance/static/js/page.js
+++ b/internal/glance/static/js/page.js
@@ -142,7 +142,10 @@ function setupSearchBoxes() {
                     return;
                 }
 
-                const url = searchUrlTemplate.replace("!QUERY!", encodeURIComponent(query));
+                const url = currentBang.dataset.raw === "true"
+                    ? searchUrlTemplate.replace("!QUERY!", query)
+                    : searchUrlTemplate.replace("!QUERY!", encodeURIComponent(query));
+
 
                 if (newTab && !event.ctrlKey || !newTab && event.ctrlKey) {
                     window.open(url, target).focus();

--- a/internal/glance/templates/search.html
+++ b/internal/glance/templates/search.html
@@ -6,7 +6,7 @@
 <div class="search widget-content-frame padding-inline-widget flex gap-15 items-center" data-default-search-url="{{ .SearchEngine }}" data-new-tab="{{ .NewTab }}" data-target="{{ .Target }}">
     <div class="search-bangs">
         {{ range .Bangs }}
-        <input type="hidden" data-shortcut="{{ .Shortcut }}" data-title="{{ .Title }}" data-url="{{ .URL }}">
+        <input type="hidden" data-shortcut="{{ .Shortcut }}" data-title="{{ .Title }}" data-url="{{ .URL }}" data-raw="{{ .RawQuery }}">
         {{ end }}
     </div>
 

--- a/internal/glance/widget-search.go
+++ b/internal/glance/widget-search.go
@@ -12,6 +12,7 @@ type SearchBang struct {
 	Title    string
 	Shortcut string
 	URL      string
+	RawQuery bool `yaml:"raw-query"`
 }
 
 type searchWidget struct {


### PR DESCRIPTION
This PR introduces a new optional `raw-query` flag for search bangs, giving users control over whether `{QUERY}` is URL encoded before being inserted into the bang URL.

### What this changes

* Adds `raw-query: boolean` to the bang configuration schema.
* Defaults to `false` to preserve the existing behavior.
* When `raw-query: true`, `{QUERY}` is substituted as-is, without `encodeURIComponent`.
* Updates:
  * Documentation (`configuration.md`)
  * HTML template (`search.html`)
  * Client-side behavior (`page.js`)
  * Bang struct (`widget-search.go`)
  
### Why

This resolves issue #527, allowing certain shortcuts to receive an unencoded path-style query. This is especially useful for URLs where slashes or special characters are meaningful, such as GitHub paths.