### PR TITLE
feat: add regex option for search bangs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1264,11 +1264,12 @@ What now? [Bangs](https://duckduckgo.com/bangs). They're shortcuts that allow yo
 ![](images/search-widget-bangs-preview.png)
 
 ##### Properties for each bang
-| Name | Type | Required |
-| ---- | ---- | -------- |
-| title | string | no |
-| shortcut | string | yes |
-| url | string | yes |
+| Name | Type | Required | Default |
+| ---- | ---- | -------- | ------- |
+| title | string | no | |
+| shortcut | string | yes | |
+| url | string | yes | |
+| regex | string | no | |
 
 ###### `title`
 Optional title that will appear on the right side of the search bar when the query starts with the associated shortcut.
@@ -1290,6 +1291,41 @@ The URL of the search engine. Use `{QUERY}` to indicate where the query value ge
 url: https://www.reddit.com/search?q={QUERY}
 url: https://store.steampowered.com/search/?term={QUERY}
 url: https://www.amazon.com/s?k={QUERY}
+```
+
+###### `regex`
+Optional regular expression that extracts multiple values from the query. If provided, the regex is applied to the query after removing the bang shortcut.
+
+Example: 
+
+```yaml
+- title: Google Translate
+  shortcut: "!tl"
+  regex: "^(\\w+):(\\w+)\\s+(.+)$"
+  url: "https://translate.google.com/?sl={QUERY}&tl={QUERY}&text={QUERY}&op=translate"
+```
+
+Typing
+
+```
+!tl en:fr hello world
+```
+
+would result in final URL being
+
+```
+https://translate.google.com/?sl=en&tl=fr&text=hello%20world&op=translate
+```
+and 
+
+```
+!tl auto:en bonjour le monde
+```
+
+would result in final URL being
+
+```
+https://translate.google.com/?sl=auto&tl=en&text=bonjour%20le%20monde&op=translate
 ```
 
 ### Group

--- a/internal/glance/static/js/page.js
+++ b/internal/glance/static/js/page.js
@@ -134,6 +134,14 @@ function setupSearchBoxes() {
                 if (currentBang != null) {
                     query = input.slice(currentBang.dataset.shortcut.length + 1);
                     searchUrlTemplate = currentBang.dataset.url;
+                    const regexString = currentBang.dataset.regex;
+                    const match = regexString && query.match(new RegExp(regexString));
+                    if (match) {
+                      query = match.at(-1);
+                      match.slice(1, -1).forEach((m) => {
+                        searchUrlTemplate = searchUrlTemplate.replace("!QUERY!", encodeURIComponent(m));
+                      });
+                    }
                 } else {
                     query = input;
                     searchUrlTemplate = defaultSearchUrl;

--- a/internal/glance/templates/search.html
+++ b/internal/glance/templates/search.html
@@ -6,7 +6,7 @@
 <div class="search widget-content-frame padding-inline-widget flex gap-15 items-center" data-default-search-url="{{ .SearchEngine }}" data-new-tab="{{ .NewTab }}" data-target="{{ .Target }}">
     <div class="search-bangs">
         {{ range .Bangs }}
-        <input type="hidden" data-shortcut="{{ .Shortcut }}" data-title="{{ .Title }}" data-url="{{ .URL }}">
+        <input type="hidden" data-shortcut="{{ .Shortcut }}" data-title="{{ .Title }}" data-url="{{ .URL }}" data-regex="{{ .Regex }}">
         {{ end }}
     </div>
 

--- a/internal/glance/widget-search.go
+++ b/internal/glance/widget-search.go
@@ -12,6 +12,7 @@ type SearchBang struct {
 	Title    string
 	Shortcut string
 	URL      string
+	Regex    string
 }
 
 type searchWidget struct {


### PR DESCRIPTION
This PR introduces a new optional `regex` field for search bangs, enabling advanced parsing of the user’s query. This allows bangs to extract multiple components from a query and substitute them into the final URL.

### What this changes

* Adds regex: string to the bang configuration schema.
* Optional; preserves existing behavior if omitted.
* When provided, the regex is applied to the query after removing the bang shortcut.
* Updates:
  * Documentation (`configuration.md`)
  * HTML template (`search.html`)
  * Client-side behavior (`page.js`)
  * Bang struct (`widget-search.go`)

### Why

This resolves issue #898, allowing certain shortcuts to extract multiple values from a query using a regular expression. This is especially useful for URLs that require structured query parameters, such as language codes or specific identifiers.
