### PR TITLE
Added sticky desktop navigation

### DIFF
--- a/internal/glance/config.go
+++ b/internal/glance/config.go
@@ -75,15 +75,16 @@ type user struct {
 }
 
 type page struct {
-	Title                  string  `yaml:"name"`
-	Slug                   string  `yaml:"slug"`
-	Width                  string  `yaml:"width"`
-	DesktopNavigationWidth string  `yaml:"desktop-navigation-width"`
-	ShowMobileHeader       bool    `yaml:"show-mobile-header"`
-	HideDesktopNavigation  bool    `yaml:"hide-desktop-navigation"`
-	CenterVertically       bool    `yaml:"center-vertically"`
-	HeadWidgets            widgets `yaml:"head-widgets"`
-	Columns                []struct {
+	Title                  	string  `yaml:"name"`
+	Slug                   	string  `yaml:"slug"`
+	Width                  	string  `yaml:"width"`
+	DesktopNavigationWidth 	string  `yaml:"desktop-navigation-width"`
+	ShowMobileHeader        bool    `yaml:"show-mobile-header"`
+	HideDesktopNavigation   bool    `yaml:"hide-desktop-navigation"`
+	StickyDesktopNavigation	bool    `yaml:"sticky-desktop-navigation"`
+	CenterVertically      	bool    `yaml:"center-vertically"`
+	HeadWidgets           	widgets `yaml:"head-widgets"`
+	Columns                 []struct {
 		Size    string  `yaml:"size"`
 		Widgets widgets `yaml:"widgets"`
 	} `yaml:"columns"`

--- a/internal/glance/static/css/site.css
+++ b/internal/glance/static/css/site.css
@@ -254,6 +254,12 @@ kbd:active {
     --header-items-gap: 2.5rem;
 }
 
+.header-container.sticky-desktop-navigation {
+    position: sticky;
+    top: 0;
+    z-index: 11;
+}
+
 .header {
     display: flex;
     height: var(--header-height);

--- a/internal/glance/templates/page.html
+++ b/internal/glance/templates/page.html
@@ -15,7 +15,7 @@
 {{ define "document-body" }}
 <div class="flex flex-column body-content">
     {{ if not .Page.HideDesktopNavigation }}
-    <div class="header-container content-bounds{{ if .Page.DesktopNavigationWidth }} content-bounds-{{ .Page.DesktopNavigationWidth }} {{ end }} {{ if .Page.StickyDesktopNavigation }} sticky-desktop-navigation {{ end }}">
+    <div class="header-container content-bounds{{ if .Page.DesktopNavigationWidth }} content-bounds-{{ .Page.DesktopNavigationWidth }}{{ end }}{{ if .Page.StickyDesktopNavigation }} sticky-desktop-navigation{{ end }}">
         <div class="header flex padding-inline-widget widget-content-frame">
             <div class="logo" aria-hidden="true">
                 {{- if .App.Config.Branding.LogoURL }}

--- a/internal/glance/templates/page.html
+++ b/internal/glance/templates/page.html
@@ -15,7 +15,7 @@
 {{ define "document-body" }}
 <div class="flex flex-column body-content">
     {{ if not .Page.HideDesktopNavigation }}
-    <div class="header-container content-bounds{{ if .Page.DesktopNavigationWidth }} content-bounds-{{ .Page.DesktopNavigationWidth }} {{ end }}">
+    <div class="header-container content-bounds{{ if .Page.DesktopNavigationWidth }} content-bounds-{{ .Page.DesktopNavigationWidth }} {{ end }} {{ if .Page.StickyDesktopNavigation }} sticky-desktop-navigation {{ end }}">
         <div class="header flex padding-inline-widget widget-content-frame">
             <div class="logo" aria-hidden="true">
                 {{- if .App.Config.Branding.LogoURL }}


### PR DESCRIPTION
<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->
```yaml
pages:
  - name: Playground
    sticky-desktop-navigation: true
```
![Screencast](https://github.com/user-attachments/assets/497012a7-ed82-433a-92cf-80ea1e2848e6)
