### PR TITLE
feat: add Ghostfolio portfolio widget

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,14 +149,14 @@ pages:
     columns:
       - size: full
         widgets:
-          $include: rss.yml
+          - $include: rss.yml
   - name: News
     columns:
       - size: full
         widgets:
           - type: group
             widgets:
-              $include: rss.yml
+              - $include: rss.yml
               - type: reddit
                 subreddit: news
 ```

--- a/internal/glance/static/css/widget-ghostfolio.css
+++ b/internal/glance/static/css/widget-ghostfolio.css
@@ -1,0 +1,220 @@
+.ghostfolio {
+    position: relative;
+}
+
+.ghostfolio-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.ghostfolio-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.ghostfolio-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.ghostfolio-value {
+    display: flex;
+    align-items: baseline;
+    gap: 0.3rem;
+}
+
+.ghostfolio-currency {
+    font-size: var(--font-size-h4);
+    color: var(--color-text-subdue);
+}
+
+.ghostfolio-amount {
+    font-size: var(--font-size-h2);
+    font-weight: 700;
+    color: var(--color-text-highlight);
+}
+
+.ghostfolio-performance {
+    display: flex;
+    align-items: baseline;
+    gap: 0.4rem;
+    font-size: var(--font-size-h4);
+}
+
+.ghostfolio-perf-value {
+    font-weight: 600;
+}
+
+.ghostfolio-perf-percent {
+    font-weight: 400;
+    opacity: 0.8;
+}
+
+/* Range Selector */
+.ghostfolio-range-selector {
+    display: flex;
+    gap: 0.3rem;
+    flex-wrap: wrap;
+}
+
+.ghostfolio-range-btn {
+    padding: 0.4rem 0.7rem;
+    font-size: var(--font-size-h6);
+    font-weight: 500;
+    background: var(--color-widget-background-highlight);
+    border: 1px solid var(--color-separator);
+    border-radius: var(--border-radius);
+    color: var(--color-text-base);
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.ghostfolio-range-btn:hover {
+    background: var(--color-separator);
+    color: var(--color-text-highlight);
+}
+
+.ghostfolio-range-btn.active {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: var(--color-background);
+}
+
+/* Chart */
+.ghostfolio-chart {
+    position: relative;
+    width: 100%;
+    /* height is set inline via chart-height parameter */
+}
+
+.ghostfolio-chart-svg {
+    width: 100%;
+    height: 100%;
+}
+
+.ghostfolio-chart-line {
+    transition: stroke 0.3s ease;
+}
+
+.ghostfolio-chart-line.positive {
+    stroke: var(--color-positive);
+}
+
+.ghostfolio-chart-line.negative {
+    stroke: var(--color-negative);
+}
+
+/* Gradient styles */
+.ghostfolio-gradient-start.positive {
+    stop-color: var(--color-positive);
+    stop-opacity: 0.3;
+}
+
+.ghostfolio-gradient-end.positive {
+    stop-color: var(--color-positive);
+    stop-opacity: 0.05;
+}
+
+.ghostfolio-gradient-start.negative {
+    stop-color: var(--color-negative);
+    stop-opacity: 0.3;
+}
+
+.ghostfolio-gradient-end.negative {
+    stop-color: var(--color-negative);
+    stop-opacity: 0.05;
+}
+
+/* Hover elements */
+.ghostfolio-hover-line {
+    stroke: var(--color-text-subdue);
+    stroke-width: 1;
+    stroke-dasharray: 2 2;
+    vector-effect: non-scaling-stroke;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+}
+
+.ghostfolio-hover-dot {
+    position: absolute;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--color-primary);
+    border: 2px solid var(--color-widget-background);
+    box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
+    transform: translate(-50%, -50%);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+}
+
+.ghostfolio-chart:hover .ghostfolio-hover-line {
+    opacity: 1;
+}
+
+.ghostfolio-chart:hover .ghostfolio-hover-dot {
+    opacity: 1;
+}
+
+/* Tooltip */
+.ghostfolio-tooltip {
+    position: absolute;
+    top: 0;
+    left: 0;
+    background: var(--color-widget-background-highlight);
+    border: 1px solid var(--color-separator);
+    border-radius: var(--border-radius);
+    padding: 0.5rem 0.75rem;
+    font-size: var(--font-size-h6);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    z-index: 10;
+    white-space: nowrap;
+}
+
+.ghostfolio-chart:hover .ghostfolio-tooltip {
+    opacity: 1;
+}
+
+.ghostfolio-tooltip-date {
+    color: var(--color-text-subdue);
+    margin-bottom: 0.25rem;
+}
+
+.ghostfolio-tooltip-value {
+    color: var(--color-text-highlight);
+    font-weight: 600;
+}
+
+.ghostfolio-tooltip-perf {
+    margin-top: 0.15rem;
+}
+
+.ghostfolio-tooltip-perf.positive {
+    color: var(--color-positive);
+}
+
+.ghostfolio-tooltip-perf.negative {
+    color: var(--color-negative);
+}
+
+/* Responsive */
+@container widget (max-width: 300px) {
+    .ghostfolio-header {
+        flex-direction: column;
+    }
+
+    .ghostfolio-range-selector {
+        width: 100%;
+        justify-content: flex-start;
+    }
+}

--- a/internal/glance/static/js/ghostfolio.js
+++ b/internal/glance/static/js/ghostfolio.js
@@ -1,0 +1,211 @@
+export default function(element) {
+    const container = element.querySelector('.ghostfolio-container');
+    const rangeButtons = element.querySelectorAll('.ghostfolio-range-btn');
+    
+    if (!container || rangeButtons.length === 0) return;
+
+    // Parse preloaded portfolio data from data attribute
+    let portfolioData;
+    try {
+        portfolioData = JSON.parse(element.dataset.portfolio || '{}');
+    } catch (e) {
+        console.error('Failed to parse Ghostfolio portfolio data:', e);
+        return;
+    }
+
+    const chartType = element.dataset.chartType || 'value';
+    let currentRange = element.dataset.defaultRange || 'max';
+
+    const currencyEl = element.querySelector('[data-currency]');
+    const amountEl = element.querySelector('[data-amount]');
+    const performanceEl = element.querySelector('[data-performance]');
+    const perfValueEl = element.querySelector('[data-perf-value]');
+    const perfPercentEl = element.querySelector('[data-perf-percent]');
+    const polygonEl = element.querySelector('[data-polygon]');
+    const polylineEl = element.querySelector('[data-polyline]');
+    const gradientStartEl = element.querySelector('[data-gradient-start]');
+    const gradientEndEl = element.querySelector('[data-gradient-end]');
+    
+    // Hover elements
+    const chartEl = element.querySelector('[data-chart]');
+    const hoverLineEl = element.querySelector('[data-hover-line]');
+    const hoverDotEl = element.querySelector('[data-hover-dot]');
+    const tooltipEl = element.querySelector('[data-tooltip]');
+    const tooltipDateEl = element.querySelector('[data-tooltip-date]');
+    const tooltipValueEl = element.querySelector('[data-tooltip-value]');
+    const tooltipPerfEl = element.querySelector('[data-tooltip-perf]');
+
+    function formatPrice(value) {
+        return value.toLocaleString('en-US', {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2
+        });
+    }
+
+    function formatDate(dateStr) {
+        const date = new Date(dateStr);
+        return date.toLocaleDateString('fr-FR', {
+            day: '2-digit',
+            month: 'short',
+            year: 'numeric'
+        });
+    }
+
+    function getChartPoints(data) {
+        if (chartType === 'performance') {
+            return data.performanceChartPoints || data.chartPoints;
+        }
+        return data.chartPoints;
+    }
+
+    function updateUI(data) {
+        if (!data || !data.hasData) return;
+
+        const isPositive = data.netPerformancePct >= 0;
+
+        // Update currency and amount
+        if (currencyEl) currencyEl.textContent = data.currency;
+        if (amountEl) amountEl.textContent = formatPrice(data.totalValue);
+
+        // Update performance colors
+        if (performanceEl) {
+            performanceEl.classList.remove('color-positive', 'color-negative');
+            performanceEl.classList.add(isPositive ? 'color-positive' : 'color-negative');
+        }
+
+        // Update performance values
+        const sign = isPositive ? '+' : '';
+        if (perfValueEl) perfValueEl.textContent = `${sign}${data.currency}${formatPrice(data.netPerformance)}`;
+        if (perfPercentEl) perfPercentEl.textContent = `(${data.netPerformancePct >= 0 ? '+' : ''}${data.netPerformancePct.toFixed(2)}%)`;
+
+        // Update chart
+        const chartPoints = getChartPoints(data);
+        if (chartPoints && polygonEl && polylineEl) {
+            polygonEl.setAttribute('points', `0,50 ${chartPoints} 100,50`);
+            polylineEl.setAttribute('points', chartPoints);
+            
+            polylineEl.classList.remove('positive', 'negative');
+            polylineEl.classList.add(isPositive ? 'positive' : 'negative');
+
+            // Update gradient classes
+            if (gradientStartEl) {
+                gradientStartEl.classList.remove('positive', 'negative');
+                gradientStartEl.classList.add(isPositive ? 'positive' : 'negative');
+            }
+            if (gradientEndEl) {
+                gradientEndEl.classList.remove('positive', 'negative');
+                gradientEndEl.classList.add(isPositive ? 'positive' : 'negative');
+            }
+        }
+    }
+
+    function switchRange(range) {
+        const data = portfolioData[range];
+        if (!data) {
+            console.warn(`No data available for range: ${range}`);
+            return;
+        }
+
+        currentRange = range;
+        updateUI(data);
+
+        // Update active button
+        rangeButtons.forEach(btn => {
+            btn.classList.toggle('active', btn.dataset.range === range);
+        });
+    }
+
+    // Hover handling for tooltip
+    function handleChartHover(e) {
+        const data = portfolioData[currentRange];
+        if (!data || !data.chartData || data.chartData.length === 0) return;
+
+        const rect = chartEl.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const relativeX = x / rect.width;
+        
+        // Find the data point index based on position
+        const index = Math.min(
+            Math.max(0, Math.round(relativeX * (data.chartData.length - 1))),
+            data.chartData.length - 1
+        );
+        
+        const point = data.chartData[index];
+        if (!point) return;
+
+        // Calculate SVG coordinates
+        const svgX = (index / (data.chartData.length - 1)) * 100;
+        
+        // Get Y value from the polyline points
+        const chartPoints = getChartPoints(data);
+        const pointsArray = chartPoints.split(' ').map(p => {
+            const [px, py] = p.split(',');
+            return { x: parseFloat(px), y: parseFloat(py) };
+        });
+        
+        // Find closest point in the polyline
+        let closestPoint = pointsArray[0];
+        let minDist = Math.abs(pointsArray[0].x - svgX);
+        for (const p of pointsArray) {
+            const dist = Math.abs(p.x - svgX);
+            if (dist < minDist) {
+                minDist = dist;
+                closestPoint = p;
+            }
+        }
+
+        // Update hover line position
+        if (hoverLineEl) {
+            hoverLineEl.setAttribute('x1', closestPoint.x);
+            hoverLineEl.setAttribute('x2', closestPoint.x);
+        }
+
+        // Update hover dot position (convert SVG coords to pixels)
+        if (hoverDotEl) {
+            const dotX = (closestPoint.x / 100) * rect.width;
+            const dotY = (closestPoint.y / 50) * rect.height;
+            hoverDotEl.style.left = `${dotX}px`;
+            hoverDotEl.style.top = `${dotY}px`;
+        }
+
+        // Update tooltip content
+        if (tooltipDateEl) tooltipDateEl.textContent = formatDate(point.date);
+        if (tooltipValueEl) tooltipValueEl.textContent = `${data.currency}${formatPrice(point.value)}`;
+        if (tooltipPerfEl) {
+            const isPositive = point.performancePct >= 0;
+            tooltipPerfEl.textContent = `${isPositive ? '+' : ''}${point.performancePct.toFixed(2)}%`;
+            tooltipPerfEl.classList.remove('positive', 'negative');
+            tooltipPerfEl.classList.add(isPositive ? 'positive' : 'negative');
+        }
+
+        // Position tooltip
+        if (tooltipEl) {
+            const tooltipWidth = tooltipEl.offsetWidth;
+            const tooltipHeight = tooltipEl.offsetHeight;
+            
+            // Calculate position relative to chart container
+            let tooltipX = x - tooltipWidth / 2;
+            let tooltipY = -tooltipHeight - 8;
+            
+            // Keep tooltip within bounds
+            if (tooltipX < 0) tooltipX = 0;
+            if (tooltipX + tooltipWidth > rect.width) tooltipX = rect.width - tooltipWidth;
+            
+            tooltipEl.style.transform = `translate(${tooltipX}px, ${tooltipY}px)`;
+        }
+    }
+
+    // Add hover event listener for tooltip
+    if (chartEl) {
+        chartEl.addEventListener('mousemove', handleChartHover);
+    }
+
+    // Add click handlers to range buttons
+    rangeButtons.forEach(button => {
+        button.addEventListener('click', () => {
+            if (!button.classList.contains('active')) {
+                switchRange(button.dataset.range);
+            }
+        });
+    });
+}

--- a/internal/glance/static/js/page.js
+++ b/internal/glance/static/js/page.js
@@ -653,6 +653,17 @@ async function setupTodos() {
     }
 }
 
+async function setupGhostfolios() {
+    const elems = Array.from(document.getElementsByClassName("ghostfolio"));
+    if (elems.length == 0) return;
+
+    const ghostfolio = await import('./ghostfolio.js');
+
+    for (let i = 0; i < elems.length; i++) {
+        ghostfolio.default(elems[i]);
+    }
+}
+
 function setupTruncatedElementTitles() {
     const elements = document.querySelectorAll(".text-truncate, .single-line-titles .title, .text-truncate-2-lines, .text-truncate-3-lines");
 
@@ -757,6 +768,7 @@ async function setupPage() {
         setupClocks()
         await setupCalendars();
         await setupTodos();
+        await setupGhostfolios();
         setupCarousels();
         setupSearchBoxes();
         setupCollapsibleLists();

--- a/internal/glance/templates/ghostfolio.html
+++ b/internal/glance/templates/ghostfolio.html
@@ -1,0 +1,71 @@
+{{ template "widget-base.html" . }}
+
+{{ define "widget-content" }}
+{{ $portfolio := .GetPortfolio }}
+{{ $chartType := .GetChartType }}
+{{ $chartHeight := .GetChartHeight }}
+<div class="ghostfolio" data-default-range="{{ .GetDefaultRange }}" data-chart-type="{{ $chartType }}" data-portfolio='{{ .GetPortfolioDataJSON }}'>
+    {{ if and $portfolio $portfolio.HasData }}
+    <div class="ghostfolio-container">
+        <div class="ghostfolio-header">
+            <div class="ghostfolio-summary">
+                <div class="ghostfolio-value">
+                    <span class="ghostfolio-currency" data-currency>{{ $portfolio.Currency }}</span>
+                    <span class="ghostfolio-amount" data-amount>{{ $portfolio.TotalValue | formatPrice }}</span>
+                </div>
+                <div class="ghostfolio-performance {{ if ge $portfolio.NetPerformancePct 0.0 }}color-positive{{ else }}color-negative{{ end }}" data-performance>
+                    <span class="ghostfolio-perf-value" data-perf-value>{{ if ge $portfolio.NetPerformance 0.0 }}+{{ end }}{{ $portfolio.Currency }}{{ $portfolio.NetPerformance | formatPrice }}</span>
+                    <span class="ghostfolio-perf-percent" data-perf-percent>({{ printf "%+.2f" $portfolio.NetPerformancePct }}%)</span>
+                </div>
+            </div>
+
+            <div class="ghostfolio-range-selector">
+                {{ range .GetRangeOptions }}
+                <button class="ghostfolio-range-btn{{ if eq $.GetDefaultRange .Value }} active{{ end }}" data-range="{{ .Value }}">
+                    {{ .Label }}
+                </button>
+                {{ end }}
+            </div>
+        </div>
+
+        <div class="ghostfolio-chart" data-chart style="height: {{ $chartHeight }}px;">
+            <svg class="ghostfolio-chart-svg" viewBox="0 0 100 50" preserveAspectRatio="none">
+                <defs>
+                    <linearGradient id="ghostfolio-gradient-{{ .GetID }}" x1="0%" y1="0%" x2="0%" y2="100%">
+                        <stop offset="0%" class="ghostfolio-gradient-start {{ if ge $portfolio.NetPerformancePct 0.0 }}positive{{ else }}negative{{ end }}" data-gradient-start />
+                        <stop offset="100%" class="ghostfolio-gradient-end {{ if ge $portfolio.NetPerformancePct 0.0 }}positive{{ else }}negative{{ end }}" data-gradient-end />
+                    </linearGradient>
+                </defs>
+                <polygon 
+                    class="ghostfolio-chart-fill"
+                    fill="url(#ghostfolio-gradient-{{ .GetID }})" 
+                    points="0,50 {{ if eq $chartType "performance" }}{{ $portfolio.PerformanceChartPoints }}{{ else }}{{ $portfolio.ChartPoints }}{{ end }} 100,50"
+                    data-polygon
+                />
+                <polyline 
+                    class="ghostfolio-chart-line {{ if ge $portfolio.NetPerformancePct 0.0 }}positive{{ else }}negative{{ end }}"
+                    fill="none" 
+                    stroke-linejoin="round" 
+                    stroke-width="2" 
+                    points="{{ if eq $chartType "performance" }}{{ $portfolio.PerformanceChartPoints }}{{ else }}{{ $portfolio.ChartPoints }}{{ end }}" 
+                    vector-effect="non-scaling-stroke"
+                    data-polyline
+                />
+                <!-- Hover line -->
+                <line class="ghostfolio-hover-line" x1="0" y1="0" x2="0" y2="50" data-hover-line />
+            </svg>
+            <!-- Hover dot (HTML element for perfect circle) -->
+            <div class="ghostfolio-hover-dot" data-hover-dot></div>
+            <!-- Tooltip -->
+            <div class="ghostfolio-tooltip" data-tooltip>
+                <div class="ghostfolio-tooltip-date" data-tooltip-date></div>
+                <div class="ghostfolio-tooltip-value" data-tooltip-value></div>
+                <div class="ghostfolio-tooltip-perf" data-tooltip-perf></div>
+            </div>
+        </div>
+    </div>
+    {{ else }}
+    <p class="color-subdue text-center">No portfolio data available</p>
+    {{ end }}
+</div>
+{{ end }}

--- a/internal/glance/widget-ghostfolio.go
+++ b/internal/glance/widget-ghostfolio.go
@@ -1,0 +1,327 @@
+package glance
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+var ghostfolioWidgetTemplate = mustParseTemplate("ghostfolio.html", "widget-base.html")
+
+type ghostfolioWidget struct {
+	widgetBase    `yaml:",inline"`
+	URL           string `yaml:"url"`
+	AccessToken   string `yaml:"access-token"`
+	DefaultRange  string `yaml:"range"`
+	ChartType     string `yaml:"chart-type"`   // "value" or "performance"
+	ChartHeight   int    `yaml:"chart-height"` // Height in pixels (default: 100)
+	AllowInsecure bool   `yaml:"allow-insecure"`
+	// All portfolio data for different ranges (preloaded)
+	PortfolioData map[string]*ghostfolioPortfolio `yaml:"-"`
+}
+
+func (widget *ghostfolioWidget) GetChartType() string {
+	return widget.ChartType
+}
+
+func (widget *ghostfolioWidget) GetChartHeight() int {
+	return widget.ChartHeight
+}
+
+type ghostfolioPortfolio struct {
+	TotalValue             float64                    `json:"totalValue"`
+	NetPerformance         float64                    `json:"netPerformance"`
+	NetPerformancePct      float64                    `json:"netPerformancePct"`
+	Currency               string                     `json:"currency"`
+	ChartPoints            string                     `json:"chartPoints"`            // Portfolio value chart
+	PerformanceChartPoints string                     `json:"performanceChartPoints"` // Performance % chart
+	ChartData              []ghostfolioChartDataPoint `json:"chartData"`              // Raw data for tooltips
+	HasData                bool                       `json:"hasData"`
+}
+
+// Simplified chart data point for frontend tooltips
+type ghostfolioChartDataPoint struct {
+	Date           string  `json:"date"`
+	Value          float64 `json:"value"`
+	PerformancePct float64 `json:"performancePct"`
+}
+
+// Available range options for the widget
+// Ghostfolio API supports: 1d, wtd, mtd, ytd, max
+var ghostfolioRangeOptions = []struct {
+	Value string
+	Label string
+}{
+	{"1d", "1D"},
+	{"wtd", "WTD"},
+	{"mtd", "MTD"},
+	{"ytd", "YTD"},
+	{"max", "Max"},
+}
+
+func (widget *ghostfolioWidget) GetRangeOptions() []struct {
+	Value string
+	Label string
+} {
+	return ghostfolioRangeOptions
+}
+
+func (widget *ghostfolioWidget) GetDefaultRange() string {
+	return widget.DefaultRange
+}
+
+func (widget *ghostfolioWidget) GetPortfolio() *ghostfolioPortfolio {
+	if widget.PortfolioData == nil {
+		return nil
+	}
+	return widget.PortfolioData[widget.DefaultRange]
+}
+
+// GetPortfolioDataJSON returns all preloaded portfolio data as JSON for the frontend
+func (widget *ghostfolioWidget) GetPortfolioDataJSON() template.JS {
+	if widget.PortfolioData == nil {
+		return template.JS("{}")
+	}
+	data, err := json.Marshal(widget.PortfolioData)
+	if err != nil {
+		return template.JS("{}")
+	}
+	return template.JS(data)
+}
+
+func (widget *ghostfolioWidget) initialize() error {
+	widget.withTitle("Portfolio").withCacheDuration(15 * time.Minute)
+
+	if widget.URL == "" {
+		return fmt.Errorf("ghostfolio widget requires a URL")
+	}
+
+	if widget.AccessToken == "" {
+		return fmt.Errorf("ghostfolio widget requires an access-token")
+	}
+
+	// Remove trailing slash from URL
+	widget.URL = strings.TrimSuffix(widget.URL, "/")
+
+	// Default range
+	if widget.DefaultRange == "" {
+		widget.DefaultRange = "max"
+	}
+
+	// Default chart type (value = portfolio value, performance = performance %)
+	if widget.ChartType == "" {
+		widget.ChartType = "value"
+	}
+
+	// Default chart height
+	if widget.ChartHeight == 0 {
+		widget.ChartHeight = 100
+	}
+
+	return nil
+}
+
+func (widget *ghostfolioWidget) update(ctx context.Context) {
+	portfolioData, err := fetchAllGhostfolioPortfolios(
+		widget.URL,
+		widget.AccessToken,
+		widget.AllowInsecure,
+	)
+
+	if !widget.canContinueUpdateAfterHandlingErr(err) {
+		return
+	}
+
+	widget.PortfolioData = portfolioData
+}
+
+func (widget *ghostfolioWidget) Render() template.HTML {
+	return widget.renderTemplate(widget, ghostfolioWidgetTemplate)
+}
+
+// Authentication response from Ghostfolio
+type ghostfolioAuthResponse struct {
+	AuthToken string `json:"authToken"`
+}
+
+// Performance API response
+type ghostfolioPerformanceResponse struct {
+	Chart []ghostfolioChartPoint `json:"chart"`
+}
+
+type ghostfolioChartPoint struct {
+	Date                    string  `json:"date"`
+	Value                   float64 `json:"value"`
+	NetPerformance          float64 `json:"netPerformance"`
+	NetPerformanceInPercent float64 `json:"netPerformanceInPercentage"`
+}
+
+// Account API response to get currency
+type ghostfolioAccountResponse struct {
+	Accounts []struct {
+		Currency string `json:"currency"`
+	} `json:"accounts"`
+}
+
+// fetchAllGhostfolioPortfolios fetches portfolio data for all range options
+func fetchAllGhostfolioPortfolios(baseURL, accessToken string, allowInsecure bool) (map[string]*ghostfolioPortfolio, error) {
+	client := ternary(allowInsecure, defaultInsecureHTTPClient, defaultHTTPClient)
+
+	// Step 1: Authenticate to get bearer token
+	bearerToken, err := ghostfolioAuthenticate(client, baseURL, accessToken)
+	if err != nil {
+		return nil, fmt.Errorf("authentication failed: %w", err)
+	}
+
+	// Step 2: Fetch account info to get currency
+	accountURL := fmt.Sprintf("%s/api/v1/account", baseURL)
+	accountReq, err := http.NewRequest("GET", accountURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	accountReq.Header.Set("Authorization", "Bearer "+bearerToken)
+	accountReq.Header.Set("Content-Type", "application/json")
+
+	accountResp, err := decodeJsonFromRequest[ghostfolioAccountResponse](client, accountReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch account: %w", err)
+	}
+
+	// Extract currency from accounts
+	currency := "EUR"
+	if len(accountResp.Accounts) > 0 && accountResp.Accounts[0].Currency != "" {
+		currency = accountResp.Accounts[0].Currency
+	}
+
+	// Convert currency code to symbol
+	currencySymbol, exists := currencyToSymbol[strings.ToUpper(currency)]
+	if !exists {
+		currencySymbol = currency
+	}
+
+	// Step 3: Fetch performance data for all ranges
+	portfolioData := make(map[string]*ghostfolioPortfolio)
+
+	for _, rangeOpt := range ghostfolioRangeOptions {
+		portfolio, err := fetchGhostfolioPerformance(client, baseURL, bearerToken, rangeOpt.Value, currencySymbol)
+		if err != nil {
+			// Continue with other ranges even if one fails
+			portfolioData[rangeOpt.Value] = &ghostfolioPortfolio{HasData: false}
+			continue
+		}
+		portfolioData[rangeOpt.Value] = portfolio
+	}
+
+	// Check if at least one range has data
+	hasAnyData := false
+	for _, p := range portfolioData {
+		if p.HasData {
+			hasAnyData = true
+			break
+		}
+	}
+
+	if !hasAnyData {
+		return nil, fmt.Errorf("no portfolio data available for any range")
+	}
+
+	return portfolioData, nil
+}
+
+func fetchGhostfolioPerformance(client requestDoer, baseURL, bearerToken, rangeParam, currencySymbol string) (*ghostfolioPortfolio, error) {
+	performanceURL := fmt.Sprintf("%s/api/v2/portfolio/performance?range=%s", baseURL, rangeParam)
+	performanceReq, err := http.NewRequest("GET", performanceURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	performanceReq.Header.Set("Authorization", "Bearer "+bearerToken)
+	performanceReq.Header.Set("Content-Type", "application/json")
+
+	performanceResp, err := decodeJsonFromRequest[ghostfolioPerformanceResponse](client, performanceReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch performance: %w", err)
+	}
+
+	// Process chart data
+	if len(performanceResp.Chart) == 0 {
+		return &ghostfolioPortfolio{HasData: false}, nil
+	}
+
+	// Extract values for the SVG charts and build chart data for tooltips
+	values := make([]float64, len(performanceResp.Chart))
+	performanceValues := make([]float64, len(performanceResp.Chart))
+	chartData := make([]ghostfolioChartDataPoint, len(performanceResp.Chart))
+
+	for i, point := range performanceResp.Chart {
+		values[i] = point.Value
+		performanceValues[i] = point.NetPerformanceInPercent * 100 // Convert to percentage
+		chartData[i] = ghostfolioChartDataPoint{
+			Date:           point.Date,
+			Value:          point.Value,
+			PerformancePct: point.NetPerformanceInPercent * 100,
+		}
+	}
+
+	// Get latest data point for summary
+	latest := performanceResp.Chart[len(performanceResp.Chart)-1]
+
+	// Generate SVG polyline coordinates for both charts
+	chartPoints := svgPolylineCoordsFromYValues(100, 50, maybeCopySliceWithoutZeroValues(values))
+	performanceChartPoints := svgPolylineCoordsFromYValues(100, 50, maybeCopySliceWithoutZeroValues(performanceValues))
+
+	return &ghostfolioPortfolio{
+		TotalValue:             latest.Value,
+		NetPerformance:         latest.NetPerformance,
+		NetPerformancePct:      latest.NetPerformanceInPercent * 100, // Convert to percentage
+		Currency:               currencySymbol,
+		ChartPoints:            chartPoints,
+		PerformanceChartPoints: performanceChartPoints,
+		ChartData:              chartData,
+		HasData:                true,
+	}, nil
+}
+
+func ghostfolioAuthenticate(client requestDoer, baseURL, accessToken string) (string, error) {
+	authURL := fmt.Sprintf("%s/api/v1/auth/anonymous", baseURL)
+
+	body, err := json.Marshal(map[string]string{
+		"accessToken": accessToken,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest("POST", authURL, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("authentication returned status %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var authResp ghostfolioAuthResponse
+	if err := json.NewDecoder(resp.Body).Decode(&authResp); err != nil {
+		return "", fmt.Errorf("failed to decode auth response: %w", err)
+	}
+
+	if authResp.AuthToken == "" {
+		return "", fmt.Errorf("empty auth token received")
+	}
+
+	return authResp.AuthToken, nil
+}

--- a/internal/glance/widget.go
+++ b/internal/glance/widget.go
@@ -81,6 +81,8 @@ func newWidget(widgetType string) (widget, error) {
 		w = &serverStatsWidget{}
 	case "to-do":
 		w = &todoWidget{}
+	case "ghostfolio":
+		w = &ghostfolioWidget{}
 	default:
 		return nil, fmt.Errorf("unknown widget type: %s", widgetType)
 	}


### PR DESCRIPTION
## Description
Adds a new widget for [Ghostfolio](https://ghostfolio.dev/), a self-hosted portfolio tracker.

## Features
- Display portfolio value and performance
- Interactive chart with tooltip on hover
- Range selector (1D, WTD, MTD, YTD, Max)
- Configurable chart type (value or performance %)
- Configurable chart height
- Positive/negative color indicators

## Configuration
```
- type: ghostfolio
  url: https://ghostfolio.example.com
  access-token: YOUR_TOKEN
  range: max
  chart-type: value
  chart-height: 150## Screenshots
```

## Screenshots
<img width="964" height="357" alt="image" src="https://github.com/user-attachments/assets/40ef84f6-f9a3-4712-abce-fbf7b1f27792" />
