### PR TITLE
feat: Adding URL Detection support into the search widget

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,14 +149,14 @@ pages:
     columns:
       - size: full
         widgets:
-          $include: rss.yml
+          - $include: rss.yml
   - name: News
     columns:
       - size: full
         widgets:
           - type: group
             widgets:
-              $include: rss.yml
+              - $include: rss.yml
               - type: reddit
                 subreddit: news
 ```

--- a/internal/glance/templates/search.html
+++ b/internal/glance/templates/search.html
@@ -21,4 +21,49 @@
     <div class="search-bang"></div>
     <kbd class="hide-on-mobile" title="Press [S] to focus the search input">S</kbd>
 </div>
+
+<script>
+(function() {
+    const searchWidget = document.currentScript.previousElementSibling;
+    const input = searchWidget.querySelector('.search-input');
+    
+    const detectUrlEnabled = searchWidget.getAttribute('data-detect-url') === 'true';
+    const defaultNewTab = searchWidget.getAttribute('data-new-tab') === 'true';
+    const targetAttr = searchWidget.getAttribute('data-target') || '_self';
+
+    function isUrl(str) {
+        if (str.includes(' ')) return false;
+        return str.includes('.') || str.startsWith('localhost');
+    }
+
+    input.addEventListener('keydown', function(e) {
+        if (e.key !== 'Enter') return;
+
+        const val = input.value.trim();
+
+        if (detectUrlEnabled && isUrl(val)) {
+            
+            e.preventDefault();
+            e.stopImmediatePropagation();
+
+            let url = val;
+            if (!/^https?:\/\//i.test(url)) {
+                url = 'https://' + url;
+            }
+
+            let shouldOpenNewTab = defaultNewTab;
+            
+            if (e.ctrlKey || e.metaKey) {
+                shouldOpenNewTab = !defaultNewTab;
+            }
+
+            if (shouldOpenNewTab) {
+                window.open(url, '_blank');
+            } else {
+                window.location.href = url;
+            }
+        }
+    });
+});
+</script>
 {{ end }}

--- a/internal/glance/widget-search.go
+++ b/internal/glance/widget-search.go
@@ -23,6 +23,8 @@ type searchWidget struct {
 	Target       string        `yaml:"target"`
 	Autofocus    bool          `yaml:"autofocus"`
 	Placeholder  string        `yaml:"placeholder"`
+	// Bool to detect urls from search
+	DetectURL    bool          `yaml:"detect-url"`
 }
 
 func convertSearchUrl(url string) string {


### PR DESCRIPTION
Changed widget-search.go to include a "DetectURL" boolean for the search widget to detect URLs (default is false), and also added to the "search.html" a script to handle it's configuration depending on how the user has set up his widget, detecting if the query is a url, if "https://" scheme is present and adding it if needed, and how to handle the query going forward.

Idk if this is a good way of doing it... It's my first pull request... I just really liked the project and wanted to try and contribute to a feature that I would like to have.