### PR TITLE
Click on video thumbnail to open video

### DIFF
--- a/internal/glance/static/css/widget-videos.css
+++ b/internal/glance/static/css/widget-videos.css
@@ -3,6 +3,7 @@
     aspect-ratio: 16 / 8.9;
     object-fit: cover;
     border-radius: var(--border-radius) var(--border-radius) 0 0;
+    cursor: pointer;
 }
 
 .video-horizontal-list-thumbnail {

--- a/internal/glance/templates/video-card-contents.html
+++ b/internal/glance/templates/video-card-contents.html
@@ -1,5 +1,5 @@
 {{ define "video-card-contents" }}
-<img class="video-thumbnail thumbnail" loading="lazy" src="{{ .ThumbnailUrl }}" alt="">
+<img class="video-thumbnail thumbnail" loading="lazy" src="{{ .ThumbnailUrl }}" alt="" onclick="window.open('{{ .Url | safeURL }}', '_blank', 'noopener,noreferrer')">
 <div class="margin-top-10 margin-bottom-widget flex flex-column grow padding-inline-widget">
     <a class="text-truncate-2-lines margin-bottom-auto color-primary-if-not-visited" href="{{ .Url | safeURL }}" target="_blank" rel="noreferrer">{{ .Title }}</a>
     <ul class="list-horizontal-text flex-nowrap margin-top-7">


### PR DESCRIPTION
Added
```
cursor: pointer
```
to the css for the widget

Added `onclick` event for thumbnail

refers to #963 

<img width="759" height="367" alt="2026-02-20_18-08" src="https://github.com/user-attachments/assets/ba53eafd-5282-43a3-88f8-81ec9cf9692f" />
