### PR TITLE
feat: Allow custom range and interval in market widget

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2842,12 +2842,14 @@ symbol-link-template: https://www.google.com/search?tbm=nws&q={SYMBOL}
 ```
 
 ###### Properties for each market
-| Name | Type | Required |
-| ---- | ---- | -------- |
-| symbol | string | yes |
-| name | string | no |
-| symbol-link | string | no |
-| chart-link | string | no |
+| Name | Type | Required | Default |
+| ---- | ---- | -------- | ------- |
+| symbol | string | yes | |
+| name | string | no | |
+| symbol-link | string | no | |
+| chart-link | string | no | |
+| range | string | no | `1mo` |
+| interval | string | no | `1d` |
 
 `symbol`
 
@@ -2864,6 +2866,17 @@ The link to go to when clicking on the symbol.
 `chart-link`
 
 The link to go to when clicking on the chart.
+
+`range`
+
+The time range of historical data shown in the chart. Valid values: `1d` `5d` `1mo` `3mo` `6mo` `1y` `2y` `5y` `10y` `ytd` `max`.
+
+`interval`
+
+The interval between data points in the chart. Valid values: `1m` `2m` `5m` `15m` `30m` `60m` `90m` `1h` `4h` `1d` `5d` `1wk` `1mo` `3mo`.
+
+> [!NOTE]
+> Not all range/interval combinations are supported by Yahoo Finance. Generally, shorter intervals (e.g. `1m`) are only available for shorter ranges (e.g. `1d` or `5d`).
 
 ### Twitch Channels
 Display a list of channels from Twitch.

--- a/internal/glance/widget-markets.go
+++ b/internal/glance/widget-markets.go
@@ -42,6 +42,18 @@ func (widget *marketsWidget) initialize() error {
 		if widget.SymbolLinkTemplate != "" && m.SymbolLink == "" {
 			m.SymbolLink = strings.ReplaceAll(widget.SymbolLinkTemplate, "{SYMBOL}", m.Symbol)
 		}
+
+		if m.Range == "" {
+			m.Range = "1mo"
+		} else if !marketValidRanges[m.Range] {
+			return fmt.Errorf("invalid range %q for symbol %s, valid values: 1d 5d 1mo 3mo 6mo 1y 2y 5y 10y ytd max", m.Range, m.Symbol)
+		}
+
+		if m.Interval == "" {
+			m.Interval = "1d"
+		} else if !marketValidIntervals[m.Interval] {
+			return fmt.Errorf("invalid interval %q for symbol %s, valid values: 1m 2m 5m 15m 30m 60m 90m 1h 4h 1d 5d 1wk 1mo 3mo", m.Interval, m.Symbol)
+		}
 	}
 
 	return nil
@@ -72,6 +84,8 @@ type marketRequest struct {
 	Symbol     string `yaml:"symbol"`
 	ChartLink  string `yaml:"chart-link"`
 	SymbolLink string `yaml:"symbol-link"`
+	Range      string `yaml:"range"`
+	Interval   string `yaml:"interval"`
 }
 
 type market struct {
@@ -126,7 +140,13 @@ func fetchMarketsDataFromYahoo(marketRequests []marketRequest) (marketList, erro
 	requests := make([]*http.Request, 0, len(marketRequests))
 
 	for i := range marketRequests {
-		request, _ := http.NewRequest("GET", fmt.Sprintf("https://query1.finance.yahoo.com/v8/finance/chart/%s?range=1mo&interval=1d", marketRequests[i].Symbol), nil)
+		url := fmt.Sprintf(
+			"https://query1.finance.yahoo.com/v8/finance/chart/%s?range=%s&interval=%s",
+			marketRequests[i].Symbol,
+			marketRequests[i].Range,
+			marketRequests[i].Interval,
+		)
+		request, _ := http.NewRequest("GET", url, nil)
 		setBrowserUserAgentHeader(request)
 		requests = append(requests, request)
 	}
@@ -231,4 +251,15 @@ var currencyToSymbol = map[string]string{
 	"DKK": "kr",
 	"PLN": "zł",
 	"PHP": "₱",
+}
+
+var marketValidRanges = map[string]bool{
+	"1d": true, "5d": true, "1mo": true, "3mo": true, "6mo": true,
+	"1y": true, "2y": true, "5y": true, "10y": true, "ytd": true, "max": true,
+}
+
+var marketValidIntervals = map[string]bool{
+	"1m": true, "2m": true, "5m": true, "15m": true, "30m": true,
+	"60m": true, "90m": true, "1h": true, "4h": true,
+	"1d": true, "5d": true, "1wk": true, "1mo": true, "3mo": true,
 }


### PR DESCRIPTION
Closes #974

## Summary

This PR adds support for customizing the range and interval parameters used when fetching chart data for the market widget.

Previously, the API request hardcoded these values:

`https://query1.finance.yahoo.com/v8/finance/chart/%s?range=1mo&interval=1d`

This now allows us to use custom range and also to fetch data for symbols that require different parameters as mentioned in issue #974 (e.g. `VNINDEX` only returns data with a `4h` interval and a short range).

## Changes

  - Added `range` and `interval` fields to the `marketRequest` struct
  - Defaults to `range: 1mo` / `interval: 1d` when not specified (fully backwards compatible)
  - Returns a clear config error for invalid values at startup
  - Updated `docs/configuration.md` with the new properties and valid values

## Example

 ```yaml
- type: markets
  markets:
    - symbol: SPY
      name: S&P 500
    - symbol: BTC-USD
      name: Bitcoin
      chart-link: https://www.tradingview.com/chart/?symbol=INDEX:BTCUSD
    - symbol: NVDA
      name: NVIDIA
    - symbol: AAPL
      symbol-link: https://www.google.com/search?tbm=nws&q=apple
      name: Apple
    - symbol: ^VNINDEX.VN
      name: VNINDEX (4h)
      interval: 4h
      range: 1mo
```

### Screenshot
<img width="400" height="579" alt="image" src="https://github.com/user-attachments/assets/eb9b8f59-1380-4bbf-b663-c5fc7867f20b" />