### PR TITLE
feat: async per-widget loading with individual placeholders

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -301,6 +301,7 @@ server:
 | proxied | boolean | no | false |
 | base-url | string | no | |
 | assets-path | string | no |  |
+| async-loading | boolean | no | false |
 
 #### `host`
 The address which the server will listen on. Setting it to `localhost` means that only the machine that the server is running on will be able to access the dashboard. By default it will listen on all interfaces.
@@ -353,6 +354,16 @@ To be able to point to an asset from your assets path, use the `/assets/` path l
 
 ```yaml
 icon: /assets/gitea-icon.png
+```
+
+#### `async-loading`
+When set to `true`, the page skeleton with loading placeholders is rendered immediately and each widget fetches its content independently. Fast widgets appear instantly while slow ones show a loading spinner without blocking the rest. If a widget fails to load, it will automatically retry up to 3 times with visual feedback.
+
+When set to `false` (default), the server waits for all widgets to finish loading before returning the page content.
+
+```yaml
+server:
+  async-loading: true
 ```
 
 ## Document

--- a/internal/glance/config.go
+++ b/internal/glance/config.go
@@ -29,11 +29,12 @@ const (
 
 type config struct {
 	Server struct {
-		Host       string `yaml:"host"`
-		Port       uint16 `yaml:"port"`
-		Proxied    bool   `yaml:"proxied"`
-		AssetsPath string `yaml:"assets-path"`
-		BaseURL    string `yaml:"base-url"`
+		Host         string `yaml:"host"`
+		Port         uint16 `yaml:"port"`
+		Proxied      bool   `yaml:"proxied"`
+		AssetsPath   string `yaml:"assets-path"`
+		BaseURL      string `yaml:"base-url"`
+		AsyncLoading bool   `yaml:"async-loading"`
 	} `yaml:"server"`
 
 	Auth struct {

--- a/internal/glance/glance.go
+++ b/internal/glance/glance.go
@@ -344,18 +344,23 @@ func (a *application) handlePageContentRequest(w http.ResponseWriter, r *http.Re
 
 	pageData := templateData{
 		Page: page,
+		App:  a,
 	}
 
 	var err error
 	var responseBytes bytes.Buffer
 
-	func() {
-		page.mu.Lock()
-		defer page.mu.Unlock()
-
-		page.updateOutdatedWidgets()
+	if a.Config.Server.AsyncLoading {
 		err = pageContentTemplate.Execute(&responseBytes, pageData)
-	}()
+	} else {
+		func() {
+			page.mu.Lock()
+			defer page.mu.Unlock()
+
+			page.updateOutdatedWidgets()
+			err = pageContentTemplate.Execute(&responseBytes, pageData)
+		}()
+	}
 
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -402,26 +407,42 @@ func (a *application) handleNotFound(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (a *application) handleWidgetRequest(w http.ResponseWriter, r *http.Request) {
-	// TODO: this requires a rework of the widget update logic so that rather
-	// than locking the entire page we lock individual widgets
-	w.WriteHeader(http.StatusNotImplemented)
+	if a.handleUnauthorizedResponse(w, r, showUnauthorizedJSON) {
+		return
+	}
 
-	// widgetValue := r.PathValue("widget")
+	widgetID, err := strconv.ParseUint(r.PathValue("widget"), 10, 64)
+	if err != nil {
+		a.handleNotFound(w, r)
+		return
+	}
 
-	// widgetID, err := strconv.ParseUint(widgetValue, 10, 64)
-	// if err != nil {
-	// 	a.handleNotFound(w, r)
-	// 	return
-	// }
+	wgt, exists := a.widgetByID[widgetID]
+	if !exists {
+		a.handleNotFound(w, r)
+		return
+	}
 
-	// widget, exists := a.widgetByID[widgetID]
+	path := r.PathValue("path")
+	if path == "render" {
+		a.handleWidgetRenderRequest(w, r, wgt)
+		return
+	}
 
-	// if !exists {
-	// 	a.handleNotFound(w, r)
-	// 	return
-	// }
+	wgt.handleRequest(w, r)
+}
 
-	// widget.handleRequest(w, r)
+func (a *application) handleWidgetRenderRequest(w http.ResponseWriter, r *http.Request, wgt widget) {
+	wgt.lock()
+	defer wgt.unlock()
+
+	now := time.Now()
+	if wgt.requiresUpdate(&now) {
+		wgt.update(context.Background())
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write([]byte(wgt.Render()))
 }
 
 func (a *application) StaticAssetPath(asset string) string {

--- a/internal/glance/static/css/site.css
+++ b/internal/glance/static/css/site.css
@@ -405,3 +405,43 @@ kbd:active {
 .theme-picker.popover-active .current-theme-preview, .theme-picker:hover {
     opacity: 1;
 }
+
+.page-column {
+    display: flex;
+    flex-direction: column;
+}
+
+.widget-loading {
+    flex: 1;
+    min-height: 10rem;
+}
+
+.widget-loading-spinner {
+    padding: var(--widget-content-padding);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    font-size: 1rem;
+}
+
+.widget-retry-notice {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.6rem;
+}
+
+.widget-retry-notice span {
+    font-size: 0.85rem;
+    color: var(--color-text-subdue);
+}
+
+.widget-fade-in {
+    animation: widgetFadeIn .3s ease-out;
+}
+
+@keyframes widgetFadeIn {
+    from { opacity: 0; transform: translateY(4px); }
+    to   { opacity: 1; transform: translateY(0); }
+}

--- a/internal/glance/static/js/masonry.js
+++ b/internal/glance/static/js/masonry.js
@@ -1,8 +1,9 @@
 
 import { clamp } from "./utils.js";
 
-export function setupMasonries() {
-    const masonryContainers = document.getElementsByClassName("masonry");
+export function setupMasonries(root) {
+    root = root || document;
+    const masonryContainers = root.getElementsByClassName("masonry");
 
     for (let i = 0; i < masonryContainers.length; i++) {
         const container = masonryContainers[i];

--- a/internal/glance/static/js/page.js
+++ b/internal/glance/static/js/page.js
@@ -12,8 +12,9 @@ async function fetchPageContent(pageData) {
     return content;
 }
 
-function setupCarousels() {
-    const carouselElements = document.getElementsByClassName("carousel-container");
+function setupCarousels(root) {
+    root = root || document;
+    const carouselElements = root.getElementsByClassName("carousel-container");
 
     if (carouselElements.length == 0) {
         return;
@@ -95,8 +96,11 @@ function updateRelativeTimeForElements(elements)
     }
 }
 
-function setupSearchBoxes() {
-    const searchWidgets = document.getElementsByClassName("search");
+let searchKeyListenerRegistered = false;
+
+function setupSearchBoxes(root) {
+    root = root || document;
+    const searchWidgets = root.getElementsByClassName("search");
 
     if (searchWidgets.length == 0) {
         return;
@@ -192,13 +196,19 @@ function setupSearchBoxes() {
             document.removeEventListener("input", handleInput);
         });
 
-        document.addEventListener("keydown", (event) => {
-            if (['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) return;
-            if (event.code != "KeyS") return;
+        if (!searchKeyListenerRegistered) {
+            searchKeyListenerRegistered = true;
+            document.addEventListener("keydown", (event) => {
+                if (['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) return;
+                if (event.code != "KeyS") return;
 
-            inputElement.focus();
-            event.preventDefault();
-        });
+                const firstSearchInput = document.querySelector(".search .search-input");
+                if (firstSearchInput) {
+                    firstSearchInput.focus();
+                    event.preventDefault();
+                }
+            });
+        }
 
         kbdElement.addEventListener("mousedown", () => {
             requestAnimationFrame(() => inputElement.focus());
@@ -206,15 +216,33 @@ function setupSearchBoxes() {
     }
 }
 
-function setupDynamicRelativeTime() {
-    const elements = document.querySelectorAll("[data-dynamic-relative-time]");
-    const updateInterval = 60 * 1000;
-    let lastUpdateTime = Date.now();
+const allRelativeTimeElements = [];
+let relativeTimeTimerStarted = false;
+
+function setupDynamicRelativeTime(root) {
+    root = root || document;
+    const elements = root.querySelectorAll("[data-dynamic-relative-time]");
+
+    if (elements.length == 0) {
+        return;
+    }
+
+    for (let i = 0; i < elements.length; i++) {
+        allRelativeTimeElements.push(elements[i]);
+    }
 
     updateRelativeTimeForElements(elements);
 
+    if (relativeTimeTimerStarted) {
+        return;
+    }
+
+    relativeTimeTimerStarted = true;
+    const updateInterval = 60 * 1000;
+    let lastUpdateTime = Date.now();
+
     const updateElementsAndTimestamp = () => {
-        updateRelativeTimeForElements(elements);
+        updateRelativeTimeForElements(allRelativeTimeElements);
         lastUpdateTime = Date.now();
     };
 
@@ -248,8 +276,9 @@ function setupDynamicRelativeTime() {
     });
 }
 
-function setupGroups() {
-    const groups = document.getElementsByClassName("widget-type-group");
+function setupGroups(root) {
+    root = root || document;
+    const groups = root.getElementsByClassName("widget-type-group");
 
     if (groups.length == 0) {
         return;
@@ -308,8 +337,9 @@ function setupGroups() {
     }
 }
 
-function setupLazyImages() {
-    const images = document.querySelectorAll("img[loading=lazy]");
+function setupLazyImages(root) {
+    root = root || document;
+    const images = root.querySelectorAll("img[loading=lazy]");
 
     if (images.length == 0) {
         return;
@@ -383,8 +413,9 @@ function attachExpandToggleButton(collapsibleContainer) {
 };
 
 
-function setupCollapsibleLists() {
-    const collapsibleLists = document.querySelectorAll(".list.collapsible-container");
+function setupCollapsibleLists(root) {
+    root = root || document;
+    const collapsibleLists = root.querySelectorAll(".list.collapsible-container");
 
     if (collapsibleLists.length == 0) {
         return;
@@ -417,8 +448,9 @@ function setupCollapsibleLists() {
     }
 }
 
-function setupCollapsibleGrids() {
-    const collapsibleGridElements = document.querySelectorAll(".cards-grid.collapsible-container");
+function setupCollapsibleGrids(root) {
+    root = root || document;
+    const collapsibleGridElements = root.querySelectorAll(".cards-grid.collapsible-container");
 
     if (collapsibleGridElements.length == 0) {
         return;
@@ -493,8 +525,13 @@ function setupCollapsibleGrids() {
 }
 
 const contentReadyCallbacks = [];
+let isContentReady = false;
 
 function afterContentReady(callback) {
+    if (isContentReady) {
+        callback();
+        return;
+    }
     contentReadyCallbacks.push(callback);
 }
 
@@ -570,8 +607,9 @@ function zoneDiffText(diffInMinutes) {
     return { text: `${sign}${hours}h~`, title: `${hours} hour${hourSuffix} and ${minutes} minutes ${signText}` };
 }
 
-function setupClocks() {
-    const clocks = document.getElementsByClassName('clock');
+function setupClocks(root) {
+    root = root || document;
+    const clocks = root.getElementsByClassName('clock');
 
     if (clocks.length == 0) {
         return;
@@ -631,8 +669,9 @@ function setupClocks() {
     updateClocks();
 }
 
-async function setupCalendars() {
-    const elems = document.getElementsByClassName("calendar");
+async function setupCalendars(root) {
+    root = root || document;
+    const elems = root.getElementsByClassName("calendar");
     if (elems.length == 0) return;
 
     // TODO: implement prefetching, currently loads as a nasty waterfall of requests
@@ -642,8 +681,9 @@ async function setupCalendars() {
         calendar.default(elems[i]);
 }
 
-async function setupTodos() {
-    const elems = Array.from(document.getElementsByClassName("todo"));
+async function setupTodos(root) {
+    root = root || document;
+    const elems = Array.from(root.getElementsByClassName("todo"));
     if (elems.length == 0) return;
 
     const todo = await import ('./todo.js');
@@ -653,8 +693,9 @@ async function setupTodos() {
     }
 }
 
-function setupTruncatedElementTitles() {
-    const elements = document.querySelectorAll(".text-truncate, .single-line-titles .title, .text-truncate-2-lines, .text-truncate-3-lines");
+function setupTruncatedElementTitles(root) {
+    root = root || document;
+    const elements = root.querySelectorAll(".text-truncate, .single-line-titles .title, .text-truncate-2-lines, .text-truncate-3-lines");
 
     if (elements.length == 0) {
         return;
@@ -743,44 +784,115 @@ function initThemePicker() {
     })
 }
 
+async function setupWidgetElement(container) {
+    setupPopovers(container);
+    setupClocks(container);
+    await setupCalendars(container);
+    await setupTodos(container);
+    setupCarousels(container);
+    setupSearchBoxes(container);
+    setupCollapsibleLists(container);
+    setupCollapsibleGrids(container);
+    setupGroups(container);
+    setupMasonries(container);
+    setupDynamicRelativeTime(container);
+    setupLazyImages(container);
+    setupTruncatedElementTitles(container);
+}
+
+async function fetchAndInsertWidget(widgetID) {
+    const placeholder = document.querySelector(`[data-widget-id="${widgetID}"]`);
+    if (!placeholder) return;
+
+    const maxRetries = 3;
+    const baseDelay = 2000;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+            const response = await fetch(`${pageData.baseURL}/api/widgets/${widgetID}/render`);
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            const html = await response.text();
+
+            const temp = document.createElement('div');
+            temp.innerHTML = html;
+            const widgetElement = temp.firstElementChild;
+            widgetElement.classList.add('widget-fade-in');
+            placeholder.replaceWith(widgetElement);
+
+            await setupWidgetElement(widgetElement);
+            return;
+        } catch (error) {
+            if (attempt < maxRetries) {
+                const spinner = placeholder.querySelector('.widget-loading-spinner');
+                if (spinner) {
+                    spinner.innerHTML =
+                        '<div class="widget-retry-notice">' +
+                            '<div class="loading-icon"></div>' +
+                            '<span>Retrying (' + attempt + '/' + maxRetries + ')...</span>' +
+                        '</div>';
+                }
+                await new Promise(resolve => setTimeout(resolve, baseDelay * attempt));
+            } else {
+                placeholder.innerHTML =
+                    '<div class="widget-content">' +
+                        '<p class="color-negative">Failed to load after ' + maxRetries + ' attempts</p>' +
+                    '</div>';
+                placeholder.classList.remove('widget-loading');
+            }
+        }
+    }
+}
+
 async function setupPage() {
     initThemePicker();
 
     const pageElement = document.getElementById("page");
     const pageContentElement = document.getElementById("page-content");
     const pageContent = await fetchPageContent(pageData);
-
     pageContentElement.innerHTML = pageContent;
 
-    try {
-        setupPopovers();
-        setupClocks()
-        await setupCalendars();
-        await setupTodos();
-        setupCarousels();
-        setupSearchBoxes();
-        setupCollapsibleLists();
-        setupCollapsibleGrids();
-        setupGroups();
-        setupMasonries();
-        setupDynamicRelativeTime();
-        setupLazyImages();
-    } finally {
+    if (pageData.asyncLoading) {
         pageElement.classList.add("content-ready");
         pageElement.setAttribute("aria-busy", "false");
-
+        isContentReady = true;
         for (let i = 0; i < contentReadyCallbacks.length; i++) {
             contentReadyCallbacks[i]();
         }
 
-        setTimeout(() => {
-            setupTruncatedElementTitles();
-        }, 50);
+        const placeholders = document.querySelectorAll('[data-widget-id]');
+        const promises = Array.from(placeholders).map(el => fetchAndInsertWidget(el.dataset.widgetId));
+        await Promise.allSettled(promises);
+    } else {
+        try {
+            setupPopovers();
+            setupClocks();
+            await setupCalendars();
+            await setupTodos();
+            setupCarousels();
+            setupSearchBoxes();
+            setupCollapsibleLists();
+            setupCollapsibleGrids();
+            setupGroups();
+            setupMasonries();
+            setupDynamicRelativeTime();
+            setupLazyImages();
+        } finally {
+            pageElement.classList.add("content-ready");
+            pageElement.setAttribute("aria-busy", "false");
+            isContentReady = true;
+            for (let i = 0; i < contentReadyCallbacks.length; i++) {
+                contentReadyCallbacks[i]();
+            }
 
-        setTimeout(() => {
-            document.body.classList.add("page-columns-transitioned");
-        }, 300);
+            setTimeout(() => {
+                setupTruncatedElementTitles();
+            }, 50);
+        }
     }
+
+    setTimeout(() => {
+        document.body.classList.add("page-columns-transitioned");
+    }, 300);
 }
 
 setupPage();

--- a/internal/glance/static/js/page.js
+++ b/internal/glance/static/js/page.js
@@ -278,7 +278,12 @@ function setupDynamicRelativeTime(root) {
 
 function setupGroups(root) {
     root = root || document;
-    const groups = root.getElementsByClassName("widget-type-group");
+    const groups = Array.from(root.getElementsByClassName("widget-type-group"));
+    // When async-loaded, root itself is the group widget — getElementsByClassName
+    // only returns descendants, so include the root explicitly.
+    if (root.classList && root.classList.contains("widget-type-group")) {
+        groups.unshift(root);
+    }
 
     if (groups.length == 0) {
         return;

--- a/internal/glance/static/js/popover.js
+++ b/internal/glance/static/js/popover.js
@@ -184,8 +184,9 @@ function handleHidePopoverOnEscape(event) {
     }
 }
 
-export function setupPopovers() {
-    const targets = document.querySelectorAll("[data-popover-type]");
+export function setupPopovers(root) {
+    root = root || document;
+    const targets = root.querySelectorAll("[data-popover-type]");
 
     for (let i = 0; i < targets.length; i++) {
         const target = targets[i];

--- a/internal/glance/templates/document.html
+++ b/internal/glance/templates/document.html
@@ -8,6 +8,7 @@
         /*{{ if .Page }}*/slug: "{{ .Page.Slug }}",/*{{ end }}*/
         baseURL: "{{ .App.Config.Server.BaseURL }}",
         theme: "{{ .Request.Theme.Key }}",
+        asyncLoading: {{ .App.Config.Server.AsyncLoading }},
     };
     </script>
     <title>{{ block "document-title" . }}{{ end }}</title>

--- a/internal/glance/templates/page-content.html
+++ b/internal/glance/templates/page-content.html
@@ -5,7 +5,13 @@
 {{ if .Page.HeadWidgets }}
 <div class="head-widgets">
     {{- range .Page.HeadWidgets }}
+    {{- if $.App.Config.Server.AsyncLoading }}
+    <div class="widget widget-loading" data-widget-id="{{ .GetID }}">
+        <div class="widget-loading-spinner"><div class="loading-icon"></div></div>
+    </div>
+    {{- else }}
     {{- .Render }}
+    {{- end }}
     {{- end }}
 </div>
 {{ end }}
@@ -14,7 +20,13 @@
 {{- range .Page.Columns }}
     <div class="page-column page-column-{{ .Size }}">
         {{- range .Widgets }}
+        {{- if $.App.Config.Server.AsyncLoading }}
+        <div class="widget widget-loading" data-widget-id="{{ .GetID }}">
+            <div class="widget-loading-spinner"><div class="loading-icon"></div></div>
+        </div>
+        {{- else }}
         {{- .Render }}
+        {{- end }}
         {{- end }}
     </div>
 {{- end }}

--- a/internal/glance/widget.go
+++ b/internal/glance/widget.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"math"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -140,6 +141,8 @@ type widget interface {
 	setID(uint64)
 	handleRequest(w http.ResponseWriter, r *http.Request)
 	setHideHeader(bool)
+	lock()
+	unlock()
 }
 
 type cacheType int
@@ -168,6 +171,7 @@ type widgetBase struct {
 	cacheType           cacheType        `yaml:"-"`
 	nextUpdate          time.Time        `yaml:"-"`
 	updateRetriedTimes  int              `yaml:"-"`
+	mu                  sync.Mutex       `yaml:"-"`
 }
 
 type widgetProviders struct {
@@ -205,6 +209,9 @@ func (w *widgetBase) setID(id uint64) {
 func (w *widgetBase) setHideHeader(value bool) {
 	w.HideHeader = value
 }
+
+func (w *widgetBase) lock()   { w.mu.Lock() }
+func (w *widgetBase) unlock() { w.mu.Unlock() }
 
 func (widget *widgetBase) handleRequest(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "not implemented", http.StatusNotImplemented)


### PR DESCRIPTION
## Summary
- Add opt-in `server.async-loading` config option that changes how the page renders widgets
- When enabled, the page skeleton appears immediately with loading spinners, and each widget fetches its content independently via `/api/widgets/{id}/render`
- Fast widgets appear instantly while slow ones show a spinner without blocking the rest
- Auto-retry (3 attempts with backoff) and fade-in animation on widget load
- When disabled (default), behavior is completely unchanged

## Test plan
- [ ] Set `async-loading: false` (or omit it) and verify the dashboard works exactly as before
- [ ] Set `async-loading: true` and verify the page skeleton renders immediately with spinners
- [ ] Verify widgets load independently and appear with a fade-in animation
- [ ] Simulate a slow/failing widget and verify retry feedback ("Retrying 1/3...")
- [ ] Verify interactive features (search, groups, carousels, popovers) work correctly after async load
- [ ] Verify cached widgets appear near-instantly on page reload