### PR TITLE
Add PageTitle field for Title fallback in change detection

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,14 +149,14 @@ pages:
     columns:
       - size: full
         widgets:
-          $include: rss.yml
+          - $include: rss.yml
   - name: News
     columns:
       - size: full
         widgets:
           - type: group
             widgets:
-              $include: rss.yml
+              - $include: rss.yml
               - type: reddit
                 subreddit: news
 ```

--- a/internal/glance/widget-changedetection.go
+++ b/internal/glance/widget-changedetection.go
@@ -89,6 +89,7 @@ func (r changeDetectionWatchList) sortByNewest() changeDetectionWatchList {
 
 type changeDetectionResponseJson struct {
 	Title        string `json:"title"`
+	PageTitle    string `json:"page_title"`
 	URL          string `json:"url"`
 	LastChanged  int64  `json:"last_changed"`
 	DateCreated  int64  `json:"date_created"`
@@ -166,6 +167,8 @@ func fetchWatchesFromChangeDetection(instanceURL string, requestedWatchIDs []str
 
 		if watchJson.Title != "" {
 			watch.Title = watchJson.Title
+		} else if watchJson.PageTitle != "" {
+			watch.Title = watchJson.PageTitle
 		} else {
 			watch.Title = strings.TrimPrefix(strings.Trim(stripURLScheme(watchJson.URL), "/"), "www.")
 		}


### PR DESCRIPTION
Introduce a new `PageTitle` field in the `changeDetectionResponseJson` to enhance title fallback logic. Update documentation to reflect these changes.

