### PR TITLE
Updating go and alpine.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.24.4-alpine3.21 AS builder
+FROM golang:1.26.1-alpine3.23 AS builder
 
 WORKDIR /app
 COPY . /app
 RUN CGO_ENABLED=0 go build .
 
-FROM alpine:3.21
+FROM alpine:3.23
 
 WORKDIR /app
 COPY --from=builder /app/glance .

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.23
 
 WORKDIR /app
 COPY glance .


### PR DESCRIPTION
Updating go (1.24.x is EOL) and alpine (only `main` support currently.).

Sources:
https://eol.wiki/go
https://eol.wiki/alpine-linux