### PR TITLE
fix: make mountpoint:info CLI command reachable

### DIFF
--- a/internal/glance/cli.go
+++ b/internal/glance/cli.go
@@ -86,11 +86,7 @@ func parseCliOptions() (*cliOptions, error) {
 	} else if len(args) == 2 {
 		if args[0] == "password:hash" {
 			intent = cliIntentPasswordHash
-		} else {
-			return nil, unknownCommandErr
-		}
-	} else if len(args) == 2 {
-		if args[0] == "mountpoint:info" {
+		} else if args[0] == "mountpoint:info" {
 			intent = cliIntentMountpointInfo
 		} else {
 			return nil, unknownCommandErr


### PR DESCRIPTION
The `mountpoint:info` command is listed in `--help` but can never execute. There are two identical `else if len(args) == 2` conditions in `parseCliOptions` — the first one (`password:hash`) always matches, making the second one (`mountpoint:info`) dead code.

```
$ glance mountpoint:info /
unknown command: mountpoint:info /
```

Merging both two-arg commands into a single `len(args) == 2` block fixes it:

```
$ glance mountpoint:info /
Path: /
FS type: apfs
Used percent: 82.4%
```

`password:hash` still works as before. Tests and `go vet` pass.

Fixes #958