### PR TITLE
fix: add safeURL pipe to RSS template URLs

### DIFF
--- a/internal/glance/templates/rss-detailed-list.html
+++ b/internal/glance/templates/rss-detailed-list.html
@@ -14,11 +14,11 @@
             {{ end }}
         </div>
         <div class="grow min-width-0">
-            <a class="size-h3 color-primary-if-not-visited" href="{{ .Link }}" target="_blank" rel="noreferrer">{{ .Title }}</a>
+            <a class="size-h3 color-primary-if-not-visited" href="{{ .Link | safeURL }}" target="_blank" rel="noreferrer">{{ .Title }}</a>
             <ul class="list-horizontal-text flex-nowrap">
                 <li {{ dynamicRelativeTimeAttrs .PublishedAt }}></li>
                 <li class="min-width-0">
-                    <a class="block text-truncate" href="{{ .ChannelURL }}" target="_blank" rel="noreferrer">{{ .ChannelName }}</a>
+                    <a class="block text-truncate" href="{{ .ChannelURL | safeURL }}" target="_blank" rel="noreferrer">{{ .ChannelName }}</a>
                 </li>
             </ul>
             {{ if ne "" .Description }}

--- a/internal/glance/templates/rss-horizontal-cards-2.html
+++ b/internal/glance/templates/rss-horizontal-cards-2.html
@@ -16,7 +16,7 @@
             </svg>
             {{ end }}
             <div class="rss-card-2-content padding-inline-widget">
-                <a href="{{ .Link }}" class="block text-truncate color-primary-if-not-visited" target="_blank" rel="noreferrer">{{ .Title }}</a>
+                <a href="{{ .Link | safeURL }}" class="block text-truncate color-primary-if-not-visited" target="_blank" rel="noreferrer">{{ .Title }}</a>
                 <ul class="list-horizontal-text flex-nowrap margin-top-5">
                     <li class="shrink-0" {{ dynamicRelativeTimeAttrs .PublishedAt }}></li>
                     <li class="min-width-0 text-truncate">{{ .ChannelName }}</li>

--- a/internal/glance/templates/rss-horizontal-cards.html
+++ b/internal/glance/templates/rss-horizontal-cards.html
@@ -16,7 +16,7 @@
             </svg>
             {{ end }}
             <div class="margin-bottom-widget padding-inline-widget flex flex-column grow">
-                <a href="{{ .Link }}" class="text-truncate-3-lines color-primary-if-not-visited margin-top-10 margin-bottom-auto" target="_blank" rel="noreferrer">{{ .Title }}</a>
+                <a href="{{ .Link | safeURL }}" class="text-truncate-3-lines color-primary-if-not-visited margin-top-10 margin-bottom-auto" target="_blank" rel="noreferrer">{{ .Title }}</a>
                 <ul class="list-horizontal-text flex-nowrap margin-top-7">
                     <li class="shrink-0" {{ dynamicRelativeTimeAttrs .PublishedAt }}></li>
                     <li class="min-width-0 text-truncate">{{ .ChannelName }}</li>

--- a/internal/glance/templates/rss-list.html
+++ b/internal/glance/templates/rss-list.html
@@ -4,11 +4,11 @@
 <ul class="list list-gap-14 collapsible-container{{ if .SingleLineTitles }} single-line-titles{{ end }}" data-collapse-after="{{ .CollapseAfter }}">
     {{ range .Items }}
     <li>
-        <a class="title size-title-dynamic color-primary-if-not-visited" href="{{ .Link }}" target="_blank" rel="noreferrer">{{ .Title }}</a>
+        <a class="title size-title-dynamic color-primary-if-not-visited" href="{{ .Link | safeURL }}" target="_blank" rel="noreferrer">{{ .Title }}</a>
         <ul class="list-horizontal-text flex-nowrap">
             <li {{ dynamicRelativeTimeAttrs .PublishedAt }}></li>
             <li class="min-width-0">
-                <a class="block text-truncate" href="{{ .ChannelURL }}" target="_blank" rel="noreferrer">{{ .ChannelName }}</a>
+                <a class="block text-truncate" href="{{ .ChannelURL | safeURL }}" target="_blank" rel="noreferrer">{{ .ChannelName }}</a>
             </li>
         </ul>
     </li>


### PR DESCRIPTION
Fixes #962

RSS feed item links are rendered as `ZgotmplZ` for certain feeds (e.g. `https://samwho.dev/rss.xml`). This is Go's `html/template` replacing URLs it doesn't trust with a safety sentinel.

The RSS templates pass `.Link` and `.ChannelURL` directly into `href` attributes without the `safeURL` pipe. Other widgets already handle this correctly — bookmarks, docker-containers, forum-posts, monitor, and videos all use `| safeURL`.

This adds the same `safeURL` pipe to all four RSS template variants:
- `rss-list.html` (`.Link` and `.ChannelURL`)
- `rss-detailed-list.html` (`.Link` and `.ChannelURL`)
- `rss-horizontal-cards.html` (`.Link`)
- `rss-horizontal-cards-2.html` (`.Link`)

The URLs are already validated/constructed in `widget-rss.go` before reaching the templates, so marking them trusted at the template layer is safe — same as every other widget does.

`go build`, `go test`, and `go vet` all pass.