### PR TITLE
feat(custom-api): add timeout option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1582,6 +1582,7 @@ Examples:
 | options | map | no | |
 | parameters | key (string) & value (string|array) | no | |
 | subrequests | map of requests | no | |
+| timeout | duration string | no | 5s |
 
 ##### `url`
 The URL to fetch the data from. It must be accessible from the server that Glance is running on.
@@ -1769,6 +1770,11 @@ parameters:
     - item1
     - item2
 ```
+
+#### `timeout`
+The maximum time to wait for the API response. The value is a string and must be a number followed by one of s, m, h, d. Example: 10s for 10 seconds, 1m for 1 minute, etc.
+
+Defaults to `5s`
 
 ### Extension
 Display a widget provided by an external source (3rd party). If you want to learn more about developing extensions, checkout the [extensions documentation](extensions.md) (WIP).

--- a/internal/glance/widget-custom-api.go
+++ b/internal/glance/widget-custom-api.go
@@ -42,6 +42,7 @@ type CustomAPIRequest struct {
 	} `yaml:"basic-auth"`
 	bodyReader  io.ReadSeeker `yaml:"-"`
 	httpRequest *http.Request `yaml:"-"`
+	Timeout     durationField `yaml:"timeout"`
 }
 
 type customAPIWidget struct {
@@ -261,6 +262,8 @@ func fetchCustomAPIResponse(ctx context.Context, req *CustomAPIRequest) (*custom
 	}
 
 	client := ternary(req.AllowInsecure, defaultInsecureHTTPClient, defaultHTTPClient)
+	client.Timeout = ternary(req.Timeout > 0, time.Duration(req.Timeout), client.Timeout)
+
 	resp, err := client.Do(req.httpRequest.WithContext(ctx))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add support for custom timeout value for `custom-api` widget.
