### PR TITLE
fix: handle HTTPS Docker endpoints without downgrading to HTTP

### DIFF
--- a/internal/glance/widget-docker-containers.go
+++ b/internal/glance/widget-docker-containers.go
@@ -286,22 +286,33 @@ func fetchDockerContainersFromSource(
 	labelOverrides map[string]map[string]string,
 ) ([]dockerContainerJsonResponse, error) {
 	var hostname string
+	var scheme string
 
 	var client *http.Client
-	if strings.HasPrefix(source, "tcp://") || strings.HasPrefix(source, "http://") {
+	if strings.HasPrefix(source, "tcp://") || strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
 		client = &http.Client{}
 		parsed, err := url.Parse(source)
 		if err != nil {
 			return nil, fmt.Errorf("parsing URL: %w", err)
 		}
 
+		scheme = parsed.Scheme
+		if scheme == "tcp" {
+			scheme = "http"
+		}
+
 		port := parsed.Port()
 		if port == "" {
-			port = "80"
+			if scheme == "https" {
+				port = "443"
+			} else {
+				port = "80"
+			}
 		}
 
 		hostname = parsed.Hostname() + ":" + port
 	} else {
+		scheme = "http"
 		hostname = "docker"
 		client = &http.Client{
 			Transport: &http.Transport{
@@ -317,7 +328,7 @@ func fetchDockerContainersFromSource(
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	request, err := http.NewRequestWithContext(ctx, "GET", "http://"+hostname+"/containers/json?all="+fetchAll, nil)
+	request, err := http.NewRequestWithContext(ctx, "GET", scheme+"://"+hostname+"/containers/json?all="+fetchAll, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Fixes Docker containers widget silently downgrading `https://` endpoints to `http://`
- The `https://` prefix was missing from the scheme check, causing HTTPS URLs to fall through to the Unix socket code path
- The request URL was hardcoded with `http://`, so even if parsed correctly, HTTPS would be lost

## Changes
- Added `https://` to the prefix check in `fetchDockerContainersFromSource`
- Captured the actual URL scheme instead of hardcoding `http://`
- Mapped `tcp://` → `http://` (preserving existing behavior)
- Default port is now `443` for HTTPS, `80` for HTTP/TCP

## Test plan
- [x] `go test ./...` passes
- [ ] Manual test with Docker endpoint over HTTPS
- [ ] Verify `tcp://` and `http://` endpoints still work as before

Fixes #992