### PR TITLE
Fix weather widget background colour

### DIFF
--- a/internal/glance/static/css/widget-weather.css
+++ b/internal/glance/static/css/widget-weather.css
@@ -104,7 +104,7 @@
 .weather-column-daylight {
     position: absolute;
     inset: 0;
-    background: linear-gradient(0deg, transparent 30px, hsl(50, 50%, 30%, 0.2));
+    background: linear-gradient(0deg, transparent 30px, hsl(var(--ths), calc(var(--scheme) ((var(--scheme) var(--bgl)) + 10%))));
 }
 
 .weather-column-daylight-sunrise {


### PR DESCRIPTION
uses theme colours

<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->
after:
<img width="275" height="212" alt="Screenshot 2026-04-29 at 3 04 53 pm" src="https://github.com/user-attachments/assets/511a8017-e0b1-4917-85ac-e17955d2622d" />

before:
<img width="258" height="203" alt="Screenshot 2026-04-29 at 3 04 20 pm" src="https://github.com/user-attachments/assets/b5215ef3-8634-432e-b50b-9f50b3b1794f" />
