### PR TITLE
feat: per-widget refresh-interval and force-refresh endpoint

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -741,7 +741,7 @@ cache: 1d  # 1 day
 > Not all widgets can have their cache duration modified. The calendar and weather widgets update on the hour and this cannot be changed.
 
 #### `refresh-interval`
-How often the widget should automatically refresh in the browser without a full page reload. Same syntax as `cache` (a number followed by `s`, `m`, `h`, or `d`). Each tick force-fetches fresh data, bypassing the widget's cache. The minimum allowed interval is 30 seconds.
+How often the widget should automatically refresh in the browser without a full page reload. Same syntax as `cache` (a number followed by `s`, `m`, `h`, or `d`). Each tick re-renders the widget; if the widget's cache hasn't expired, the existing data is reused, so a tight refresh interval is safe and won't hammer upstream APIs. Use the manual refresh button to force a fresh fetch. The minimum allowed interval is 5 seconds.
 
 ```yaml
 refresh-interval: 1m

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -707,6 +707,7 @@ pages:
 | title-url | string | no |
 | hide-header | boolean | no | false |
 | cache | string | no |
+| refresh-interval | string | no |
 | css-class | string | no |
 
 #### `type`
@@ -738,6 +739,21 @@ cache: 1d  # 1 day
 > [!NOTE]
 >
 > Not all widgets can have their cache duration modified. The calendar and weather widgets update on the hour and this cannot be changed.
+
+#### `refresh-interval`
+How often the widget should automatically refresh in the browser without a full page reload. Same syntax as `cache` (a number followed by `s`, `m`, `h`, or `d`). Each tick force-fetches fresh data, bypassing the widget's cache. The minimum allowed interval is 30 seconds.
+
+```yaml
+refresh-interval: 1m
+refresh-interval: 5m
+refresh-interval: 1h
+```
+
+When the page is hidden (tab in the background), refresh timers pause and resume on visibility — they don't fire while you're not looking.
+
+> [!NOTE]
+>
+> Not all widget types support `refresh-interval`. The following are excluded because they hold interactive client-side state, embed external content, or have no data to refresh: `calendar`, `to-do`, `clock`, `iframe`, `html`, `search`, `bookmarks`, `group`, `split-column`. Setting `refresh-interval` on any of these will fail at config load.
 
 #### `css-class`
 Set custom CSS classes for the specific widget instance.

--- a/internal/glance/config.go
+++ b/internal/glance/config.go
@@ -87,8 +87,7 @@ type page struct {
 		Size    string  `yaml:"size"`
 		Widgets widgets `yaml:"widgets"`
 	} `yaml:"columns"`
-	PrimaryColumnIndex int8       `yaml:"-"`
-	mu                 sync.Mutex `yaml:"-"`
+	PrimaryColumnIndex int8 `yaml:"-"`
 }
 
 func newConfigFromYAML(contents []byte) (*config, error) {

--- a/internal/glance/glance.go
+++ b/internal/glance/glance.go
@@ -230,10 +230,8 @@ func newApplication(c *config) (*application, error) {
 	return app, nil
 }
 
-// registerWidget adds a widget (and any contained children, recursively) to
-// app.widgetByID so the per-widget refresh endpoint can resolve them by ID.
-// Without the recursive walk, widgets nested inside group/split-column would
-// 404 when their refresh-interval ticks.
+// recursive so widgets nested inside group/split-column are also reachable
+// by ID — without this their refresh-interval ticks would 404.
 func (a *application) registerWidget(w widget) {
 	a.widgetByID[w.GetID()] = w
 	if c, ok := w.(interface{ childWidgets() []widget }); ok {

--- a/internal/glance/glance.go
+++ b/internal/glance/glance.go
@@ -246,6 +246,8 @@ func (p *page) updateOutdatedWidgets() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			widget.lock()
+			defer widget.unlock()
 			widget.update(context)
 		}()
 	}
@@ -346,16 +348,10 @@ func (a *application) handlePageContentRequest(w http.ResponseWriter, r *http.Re
 		Page: page,
 	}
 
-	var err error
 	var responseBytes bytes.Buffer
 
-	func() {
-		page.mu.Lock()
-		defer page.mu.Unlock()
-
-		page.updateOutdatedWidgets()
-		err = pageContentTemplate.Execute(&responseBytes, pageData)
-	}()
+	page.updateOutdatedWidgets()
+	err := pageContentTemplate.Execute(&responseBytes, pageData)
 
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -402,26 +398,55 @@ func (a *application) handleNotFound(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (a *application) handleWidgetRequest(w http.ResponseWriter, r *http.Request) {
-	// TODO: this requires a rework of the widget update logic so that rather
-	// than locking the entire page we lock individual widgets
-	w.WriteHeader(http.StatusNotImplemented)
+	widgetID, err := strconv.ParseUint(r.PathValue("widget"), 10, 64)
+	if err != nil {
+		a.handleNotFound(w, r)
+		return
+	}
 
-	// widgetValue := r.PathValue("widget")
+	widget, exists := a.widgetByID[widgetID]
+	if !exists {
+		a.handleNotFound(w, r)
+		return
+	}
 
-	// widgetID, err := strconv.ParseUint(widgetValue, 10, 64)
-	// if err != nil {
-	// 	a.handleNotFound(w, r)
-	// 	return
-	// }
+	widget.handleRequest(w, r)
+}
 
-	// widget, exists := a.widgetByID[widgetID]
+func (a *application) handleWidgetRefreshRequest(w http.ResponseWriter, r *http.Request) {
+	if a.handleUnauthorizedResponse(w, r, showUnauthorizedJSON) {
+		return
+	}
 
-	// if !exists {
-	// 	a.handleNotFound(w, r)
-	// 	return
-	// }
+	widgetID, err := strconv.ParseUint(r.PathValue("widget"), 10, 64)
+	if err != nil {
+		a.handleNotFound(w, r)
+		return
+	}
 
-	// widget.handleRequest(w, r)
+	widget, exists := a.widgetByID[widgetID]
+	if !exists {
+		a.handleNotFound(w, r)
+		return
+	}
+
+	force := r.URL.Query().Get("force") == "1"
+
+	func() {
+		widget.lock()
+		defer widget.unlock()
+
+		now := time.Now()
+		if force || widget.requiresUpdate(&now) {
+			widget.update(r.Context())
+		}
+	}()
+
+	// Render outside the lock; renderTemplate re-acquires it briefly.
+	// Returning the full widget element (including header) lets the client
+	// replace the widget's outerHTML without needing a separate fragment template.
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write([]byte(widget.Render()))
 }
 
 func (a *application) StaticAssetPath(asset string) string {
@@ -445,6 +470,7 @@ func (a *application) server() (func() error, func() error) {
 		mux.HandleFunc("POST /api/set-theme/{key}", a.handleThemeChangeRequest)
 	}
 
+	mux.HandleFunc("GET /api/widgets/{widget}/refresh", a.handleWidgetRefreshRequest)
 	mux.HandleFunc("/api/widgets/{widget}/{path...}", a.handleWidgetRequest)
 	mux.HandleFunc("GET /api/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/glance/glance.go
+++ b/internal/glance/glance.go
@@ -174,7 +174,7 @@ func newApplication(c *config) (*application, error) {
 
 		for i := range page.HeadWidgets {
 			widget := page.HeadWidgets[i]
-			app.widgetByID[widget.GetID()] = widget
+			app.registerWidget(widget)
 			widget.setProviders(providers)
 		}
 
@@ -187,7 +187,7 @@ func newApplication(c *config) (*application, error) {
 
 			for w := range column.Widgets {
 				widget := column.Widgets[w]
-				app.widgetByID[widget.GetID()] = widget
+				app.registerWidget(widget)
 				widget.setProviders(providers)
 			}
 		}
@@ -230,6 +230,19 @@ func newApplication(c *config) (*application, error) {
 	return app, nil
 }
 
+// registerWidget adds a widget (and any contained children, recursively) to
+// app.widgetByID so the per-widget refresh endpoint can resolve them by ID.
+// Without the recursive walk, widgets nested inside group/split-column would
+// 404 when their refresh-interval ticks.
+func (a *application) registerWidget(w widget) {
+	a.widgetByID[w.GetID()] = w
+	if c, ok := w.(interface{ childWidgets() []widget }); ok {
+		for _, child := range c.childWidgets() {
+			a.registerWidget(child)
+		}
+	}
+}
+
 func (p *page) updateOutdatedWidgets() {
 	now := time.Now()
 
@@ -248,6 +261,11 @@ func (p *page) updateOutdatedWidgets() {
 			defer wg.Done()
 			widget.lock()
 			defer widget.unlock()
+			// Re-check inside the lock: a concurrent page render may have
+			// already updated this widget while we were waiting on the mutex.
+			if !widget.requiresUpdate(&now) {
+				return
+			}
 			widget.update(context)
 		}()
 	}
@@ -263,6 +281,11 @@ func (p *page) updateOutdatedWidgets() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
+				widget.lock()
+				defer widget.unlock()
+				if !widget.requiresUpdate(&now) {
+					return
+				}
 				widget.update(context)
 			}()
 		}

--- a/internal/glance/static/js/masonry.js
+++ b/internal/glance/static/js/masonry.js
@@ -47,8 +47,8 @@ export function setupMasonries(root = document) {
         const observer = new ResizeObserver(() => requestAnimationFrame(render));
         observer.observe(container);
 
-        const widgetEl = container.closest && container.closest(".widget");
-        if (widgetEl !== null && widgetEl !== undefined) {
+        const widgetEl = container.closest(".widget");
+        if (widgetEl !== null) {
             if (!widgetEl._cleanupCallbacks) widgetEl._cleanupCallbacks = [];
             widgetEl._cleanupCallbacks.push(() => observer.disconnect());
         }

--- a/internal/glance/static/js/masonry.js
+++ b/internal/glance/static/js/masonry.js
@@ -1,8 +1,8 @@
 
 import { clamp } from "./utils.js";
 
-export function setupMasonries() {
-    const masonryContainers = document.getElementsByClassName("masonry");
+export function setupMasonries(root = document) {
+    const masonryContainers = root.getElementsByClassName("masonry");
 
     for (let i = 0; i < masonryContainers.length; i++) {
         const container = masonryContainers[i];
@@ -46,5 +46,11 @@ export function setupMasonries() {
 
         const observer = new ResizeObserver(() => requestAnimationFrame(render));
         observer.observe(container);
+
+        const widgetEl = container.closest && container.closest(".widget");
+        if (widgetEl !== null && widgetEl !== undefined) {
+            if (!widgetEl._cleanupCallbacks) widgetEl._cleanupCallbacks = [];
+            widgetEl._cleanupCallbacks.push(() => observer.disconnect());
+        }
     }
 }

--- a/internal/glance/static/js/page.js
+++ b/internal/glance/static/js/page.js
@@ -2,6 +2,26 @@ import { setupPopovers } from './popover.js';
 import { setupMasonries } from './masonry.js';
 import { throttledDebounce, isElementVisible, openURLInNewTab } from './utils.js';
 import { elem, find, findAll } from './templating.js';
+import { setupWidgetRefresh } from './widget-refresh.js';
+
+// Cleanup callbacks for things that aren't auto-released when a widget's
+// outerHTML is replaced (window/document listeners, ResizeObservers, intervals).
+// Stored on the widget's root element; run from widget-refresh.js before swap.
+function registerWidgetCleanup(target, cb) {
+    const widgetEl = target instanceof Element ? target.closest(".widget") : null;
+    if (widgetEl === null) return;
+    if (!widgetEl._cleanupCallbacks) widgetEl._cleanupCallbacks = [];
+    widgetEl._cleanupCallbacks.push(cb);
+}
+
+export function runWidgetCleanup(widgetEl) {
+    const callbacks = widgetEl._cleanupCallbacks;
+    if (!callbacks) return;
+    widgetEl._cleanupCallbacks = null;
+    for (let i = 0; i < callbacks.length; i++) {
+        try { callbacks[i](); } catch (e) { console.error(e); }
+    }
+}
 
 async function fetchPageContent(pageData) {
     // TODO: handle non 200 status codes/time outs
@@ -12,8 +32,8 @@ async function fetchPageContent(pageData) {
     return content;
 }
 
-function setupCarousels() {
-    const carouselElements = document.getElementsByClassName("carousel-container");
+function setupCarousels(root = document) {
+    const carouselElements = root.getElementsByClassName("carousel-container");
 
     if (carouselElements.length == 0) {
         return;
@@ -42,6 +62,7 @@ function setupCarousels() {
 
         itemsContainer.addEventListener("scroll", determineSideCutoffsRateLimited);
         window.addEventListener("resize", determineSideCutoffsRateLimited);
+        registerWidgetCleanup(carousel, () => window.removeEventListener("resize", determineSideCutoffsRateLimited));
 
         afterContentReady(determineSideCutoffs);
     }
@@ -206,15 +227,23 @@ function setupSearchBoxes() {
     }
 }
 
-function setupDynamicRelativeTime() {
-    const elements = document.querySelectorAll("[data-dynamic-relative-time]");
+let dynamicRelativeTimeInitialized = false;
+
+function setupDynamicRelativeTime(root = document) {
+    // Always update elements within the given root immediately so refreshed
+    // widgets show correct values right away.
+    updateRelativeTimeForElements(root.querySelectorAll("[data-dynamic-relative-time]"));
+
+    // The repeating timer is global and queries the document fresh each tick
+    // so it picks up elements introduced by widget refreshes automatically.
+    if (dynamicRelativeTimeInitialized) return;
+    dynamicRelativeTimeInitialized = true;
+
     const updateInterval = 60 * 1000;
     let lastUpdateTime = Date.now();
 
-    updateRelativeTimeForElements(elements);
-
     const updateElementsAndTimestamp = () => {
-        updateRelativeTimeForElements(elements);
+        updateRelativeTimeForElements(document.querySelectorAll("[data-dynamic-relative-time]"));
         lastUpdateTime = Date.now();
     };
 
@@ -308,8 +337,8 @@ function setupGroups() {
     }
 }
 
-function setupLazyImages() {
-    const images = document.querySelectorAll("img[loading=lazy]");
+function setupLazyImages(root = document) {
+    const images = root.querySelectorAll("img[loading=lazy]");
 
     if (images.length == 0) {
         return;
@@ -383,8 +412,8 @@ function attachExpandToggleButton(collapsibleContainer) {
 };
 
 
-function setupCollapsibleLists() {
-    const collapsibleLists = document.querySelectorAll(".list.collapsible-container");
+function setupCollapsibleLists(root = document) {
+    const collapsibleLists = root.querySelectorAll(".list.collapsible-container");
 
     if (collapsibleLists.length == 0) {
         return;
@@ -417,8 +446,8 @@ function setupCollapsibleLists() {
     }
 }
 
-function setupCollapsibleGrids() {
-    const collapsibleGridElements = document.querySelectorAll(".cards-grid.collapsible-container");
+function setupCollapsibleGrids(root = document) {
+    const collapsibleGridElements = root.querySelectorAll(".cards-grid.collapsible-container");
 
     if (collapsibleGridElements.length == 0) {
         return;
@@ -489,13 +518,32 @@ function setupCollapsibleGrids() {
         });
 
         afterContentReady(() => observer.observe(gridElement));
+        registerWidgetCleanup(gridElement, () => observer.disconnect());
     }
 }
 
 const contentReadyCallbacks = [];
+let contentReadyFired = false;
 
 function afterContentReady(callback) {
+    if (contentReadyFired) {
+        callback();
+        return;
+    }
     contentReadyCallbacks.push(callback);
+}
+
+// Re-runs the subset of setup functions that apply to widget content. Called
+// after a widget's outerHTML is replaced via the refresh endpoint.
+export function reinitWidget(rootEl) {
+    setupPopovers(rootEl);
+    setupCarousels(rootEl);
+    setupCollapsibleLists(rootEl);
+    setupCollapsibleGrids(rootEl);
+    setupMasonries(rootEl);
+    setupDynamicRelativeTime(rootEl);
+    setupLazyImages(rootEl);
+    setupTruncatedElementTitles(rootEl);
 }
 
 const weekDayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
@@ -653,8 +701,8 @@ async function setupTodos() {
     }
 }
 
-function setupTruncatedElementTitles() {
-    const elements = document.querySelectorAll(".text-truncate, .single-line-titles .title, .text-truncate-2-lines, .text-truncate-3-lines");
+function setupTruncatedElementTitles(root = document) {
+    const elements = root.querySelectorAll(".text-truncate, .single-line-titles .title, .text-truncate-2-lines, .text-truncate-3-lines");
 
     if (elements.length == 0) {
         return;
@@ -772,6 +820,9 @@ async function setupPage() {
         for (let i = 0; i < contentReadyCallbacks.length; i++) {
             contentReadyCallbacks[i]();
         }
+        contentReadyFired = true;
+
+        setupWidgetRefresh(pageData.baseURL);
 
         setTimeout(() => {
             setupTruncatedElementTitles();

--- a/internal/glance/static/js/popover.js
+++ b/internal/glance/static/js/popover.js
@@ -184,8 +184,8 @@ function handleHidePopoverOnEscape(event) {
     }
 }
 
-export function setupPopovers() {
-    const targets = document.querySelectorAll("[data-popover-type]");
+export function setupPopovers(root = document) {
+    const targets = root.querySelectorAll("[data-popover-type]");
 
     for (let i = 0; i < targets.length; i++) {
         const target = targets[i];

--- a/internal/glance/static/js/widget-refresh.js
+++ b/internal/glance/static/js/widget-refresh.js
@@ -47,16 +47,20 @@ function startInterval(id, seconds) {
     intervals.set(id, setInterval(() => refreshWidget(id, false), seconds * 1000));
 }
 
+function stopInterval(id) {
+    const handle = intervals.get(id);
+    if (handle !== undefined) {
+        clearInterval(handle);
+        intervals.delete(id);
+    }
+    intervalSeconds.delete(id);
+    lastRefreshAt.delete(id);
+}
+
 async function refreshWidget(id, force) {
     const widgetEl = document.querySelector(`.widget[data-widget-id="${CSS.escape(id)}"]`);
     if (widgetEl === null) {
-        // Widget was removed (e.g., by an earlier refresh). Drop its interval.
-        const handle = intervals.get(id);
-        if (handle !== undefined) {
-            clearInterval(handle);
-            intervals.delete(id);
-        }
-        intervalSeconds.delete(id);
+        stopInterval(id);
         return;
     }
 
@@ -69,6 +73,10 @@ async function refreshWidget(id, force) {
         const res = await fetch(url, { credentials: "same-origin" });
         if (!res.ok) {
             widgetEl.removeAttribute("aria-busy");
+            // 404 means the widget id is unknown to the server (e.g., after a
+            // config reload that reassigned ids). Don't keep retrying — a full
+            // page reload will repopulate intervals with fresh ids.
+            if (res.status === 404) stopInterval(id);
             return;
         }
         html = await res.text();

--- a/internal/glance/static/js/widget-refresh.js
+++ b/internal/glance/static/js/widget-refresh.js
@@ -1,0 +1,96 @@
+import { reinitWidget, runWidgetCleanup } from './page.js';
+
+// Per-widget interval handles, keyed by widget id. Outerhtml replacement
+// creates new DOM nodes for the widget, so id is the stable key.
+const intervals = new Map();
+const intervalSeconds = new Map();
+const lastRefreshAt = new Map();
+
+let baseURL = "";
+let visibilityListenerInstalled = false;
+
+export function setupWidgetRefresh(_baseURL) {
+    baseURL = _baseURL;
+
+    document.querySelectorAll(".widget[data-refresh-interval]").forEach((widgetEl) => {
+        const seconds = parseInt(widgetEl.dataset.refreshInterval, 10);
+        if (!seconds || seconds < 1) return;
+        const id = widgetEl.dataset.widgetId;
+        if (!id) return;
+        intervalSeconds.set(id, seconds);
+        startInterval(id, seconds);
+    });
+
+    if (visibilityListenerInstalled) return;
+    visibilityListenerInstalled = true;
+    if (document.hidden === undefined) return;
+
+    document.addEventListener("visibilitychange", () => {
+        if (document.hidden) {
+            for (const handle of intervals.values()) clearInterval(handle);
+            intervals.clear();
+            return;
+        }
+
+        const now = Date.now();
+        intervalSeconds.forEach((seconds, id) => {
+            const last = lastRefreshAt.get(id) || 0;
+            if (now - last >= seconds * 1000) refreshWidget(id, false);
+            startInterval(id, seconds);
+        });
+    });
+}
+
+function startInterval(id, seconds) {
+    const existing = intervals.get(id);
+    if (existing !== undefined) clearInterval(existing);
+    intervals.set(id, setInterval(() => refreshWidget(id, false), seconds * 1000));
+}
+
+async function refreshWidget(id, force) {
+    const widgetEl = document.querySelector(`.widget[data-widget-id="${CSS.escape(id)}"]`);
+    if (widgetEl === null) {
+        // Widget was removed (e.g., by an earlier refresh). Drop its interval.
+        const handle = intervals.get(id);
+        if (handle !== undefined) {
+            clearInterval(handle);
+            intervals.delete(id);
+        }
+        intervalSeconds.delete(id);
+        return;
+    }
+
+    widgetEl.setAttribute("aria-busy", "true");
+    lastRefreshAt.set(id, Date.now());
+
+    let html;
+    try {
+        const url = `${baseURL}/api/widgets/${encodeURIComponent(id)}/refresh${force ? "?force=1" : ""}`;
+        const res = await fetch(url, { credentials: "same-origin" });
+        if (!res.ok) {
+            widgetEl.removeAttribute("aria-busy");
+            return;
+        }
+        html = await res.text();
+    } catch (e) {
+        console.error("widget refresh failed", id, e);
+        widgetEl.removeAttribute("aria-busy");
+        return;
+    }
+
+    // Re-find in case something else swapped during the await.
+    const target = document.querySelector(`.widget[data-widget-id="${CSS.escape(id)}"]`);
+    if (target === null) return;
+
+    runWidgetCleanup(target);
+
+    const placeholder = document.createElement("div");
+    placeholder.innerHTML = html;
+    const newWidgetEl = placeholder.firstElementChild;
+    if (newWidgetEl === null) {
+        target.removeAttribute("aria-busy");
+        return;
+    }
+    target.replaceWith(newWidgetEl);
+    reinitWidget(newWidgetEl);
+}

--- a/internal/glance/templates/widget-base.html
+++ b/internal/glance/templates/widget-base.html
@@ -1,4 +1,4 @@
-<div class="widget widget-type-{{ .GetType }}{{ if .CSSClass }} {{ .CSSClass }}{{ end }}">
+<div class="widget widget-type-{{ .GetType }}{{ if .CSSClass }} {{ .CSSClass }}{{ end }}" data-widget-id="{{ .GetID }}"{{ if gt .RefreshIntervalSeconds 0 }} data-refresh-interval="{{ .RefreshIntervalSeconds }}"{{ end }}>
     {{- if not .HideHeader }}
     <div class="widget-header">
         {{- if ne "" .TitleURL }}

--- a/internal/glance/widget-container.go
+++ b/internal/glance/widget-container.go
@@ -10,6 +10,10 @@ type containerWidgetBase struct {
 	Widgets widgets `yaml:"widgets"`
 }
 
+func (widget *containerWidgetBase) childWidgets() []widget {
+	return widget.Widgets
+}
+
 func (widget *containerWidgetBase) _initializeWidgets() error {
 	for i := range widget.Widgets {
 		if err := widget.Widgets[i].initialize(); err != nil {
@@ -36,6 +40,11 @@ func (widget *containerWidgetBase) _update(ctx context.Context) {
 			defer wg.Done()
 			widget.lock()
 			defer widget.unlock()
+			// Re-check inside the lock: a concurrent page render may have
+			// already updated this widget while we were waiting on the mutex.
+			if !widget.requiresUpdate(&now) {
+				return
+			}
 			widget.update(ctx)
 		}()
 	}

--- a/internal/glance/widget-container.go
+++ b/internal/glance/widget-container.go
@@ -34,6 +34,8 @@ func (widget *containerWidgetBase) _update(ctx context.Context) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			widget.lock()
+			defer widget.unlock()
 			widget.update(ctx)
 		}()
 	}

--- a/internal/glance/widget.go
+++ b/internal/glance/widget.go
@@ -161,7 +161,11 @@ var refreshIntervalDisallowedTypes = map[string]struct{}{
 	"bookmarks":       {},
 }
 
-const minRefreshInterval = 30 * time.Second
+// minRefreshInterval is a floor against typos (e.g. accidentally writing 1s).
+// Upstream rate limiting should be handled by the widget's cache duration,
+// not by this floor — refresh-interval ticks below the cache return the same
+// data without re-fetching, so a tight client interval is safe by default.
+const minRefreshInterval = 5 * time.Second
 
 type cacheType int
 

--- a/internal/glance/widget.go
+++ b/internal/glance/widget.go
@@ -161,10 +161,8 @@ var refreshIntervalDisallowedTypes = map[string]struct{}{
 	"bookmarks":       {},
 }
 
-// minRefreshInterval is a floor against typos (e.g. accidentally writing 1s).
-// Upstream rate limiting should be handled by the widget's cache duration,
-// not by this floor — refresh-interval ticks below the cache return the same
-// data without re-fetching, so a tight client interval is safe by default.
+// floor against typos (e.g. 1s). upstream rate limiting is the cache's job,
+// not this floor — ticks below the cache window don't re-fetch.
 const minRefreshInterval = 5 * time.Second
 
 type cacheType int
@@ -251,8 +249,6 @@ func (w *widgetBase) validate() error {
 	return nil
 }
 
-// RefreshIntervalSeconds is exposed for templates to emit data-refresh-interval.
-// Returns 0 when no interval is configured.
 func (w *widgetBase) RefreshIntervalSeconds() int {
 	return int(time.Duration(w.RefreshInterval).Seconds())
 }

--- a/internal/glance/widget.go
+++ b/internal/glance/widget.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"math"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -117,6 +118,10 @@ func (w *widgets) UnmarshalYAML(node *yaml.Node) error {
 			return err
 		}
 
+		if err := widget.validate(); err != nil {
+			return fmt.Errorf("line %d: %w", node.Line, err)
+		}
+
 		*w = append(*w, widget)
 	}
 
@@ -136,7 +141,27 @@ type widget interface {
 	setID(uint64)
 	handleRequest(w http.ResponseWriter, r *http.Request)
 	setHideHeader(bool)
+	lock()
+	unlock()
+	validate() error
 }
+
+// Widgets that hold interactive client-side state, are static, or are
+// containers — none of these are valid targets for refresh-interval.
+var refreshIntervalDisallowedTypes = map[string]struct{}{
+	"calendar":        {},
+	"calendar-legacy": {},
+	"to-do":           {},
+	"clock":           {},
+	"iframe":          {},
+	"html":            {},
+	"group":           {},
+	"split-column":    {},
+	"search":          {},
+	"bookmarks":       {},
+}
+
+const minRefreshInterval = 30 * time.Second
 
 type cacheType int
 
@@ -155,6 +180,7 @@ type widgetBase struct {
 	HideHeader          bool             `yaml:"hide-header"`
 	CSSClass            string           `yaml:"css-class"`
 	CustomCacheDuration durationField    `yaml:"cache"`
+	RefreshInterval     durationField    `yaml:"refresh-interval"`
 	ContentAvailable    bool             `yaml:"-"`
 	WIP                 bool             `yaml:"-"`
 	Error               error            `yaml:"-"`
@@ -164,6 +190,9 @@ type widgetBase struct {
 	cacheType           cacheType        `yaml:"-"`
 	nextUpdate          time.Time        `yaml:"-"`
 	updateRetriedTimes  int              `yaml:"-"`
+	// mu serializes update() and renderTemplate() for this widget.
+	// Without it, concurrent requests would race on templateBuffer and update state.
+	mu sync.Mutex `yaml:"-"`
 }
 
 type widgetProviders struct {
@@ -202,6 +231,28 @@ func (w *widgetBase) setHideHeader(value bool) {
 	w.HideHeader = value
 }
 
+func (w *widgetBase) lock()   { w.mu.Lock() }
+func (w *widgetBase) unlock() { w.mu.Unlock() }
+
+func (w *widgetBase) validate() error {
+	if w.RefreshInterval == 0 {
+		return nil
+	}
+	if _, ok := refreshIntervalDisallowedTypes[w.Type]; ok {
+		return fmt.Errorf("widget type %q does not support refresh-interval", w.Type)
+	}
+	if time.Duration(w.RefreshInterval) < minRefreshInterval {
+		return fmt.Errorf("refresh-interval must be at least %s", minRefreshInterval)
+	}
+	return nil
+}
+
+// RefreshIntervalSeconds is exposed for templates to emit data-refresh-interval.
+// Returns 0 when no interval is configured.
+func (w *widgetBase) RefreshIntervalSeconds() int {
+	return int(time.Duration(w.RefreshInterval).Seconds())
+}
+
 func (widget *widgetBase) handleRequest(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "not implemented", http.StatusNotImplemented)
 }
@@ -215,6 +266,9 @@ func (w *widgetBase) setProviders(providers *widgetProviders) {
 }
 
 func (w *widgetBase) renderTemplate(data any, t *template.Template) template.HTML {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	w.templateBuffer.Reset()
 	err := t.Execute(&w.templateBuffer, data)
 	if err != nil {

--- a/internal/glance/widget_test.go
+++ b/internal/glance/widget_test.go
@@ -1,0 +1,49 @@
+package glance
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWidgetValidateRefreshInterval(t *testing.T) {
+	tests := []struct {
+		name        string
+		widgetType  string
+		interval    time.Duration
+		errContains string
+	}{
+		{name: "no interval is allowed on any type", widgetType: "clock", interval: 0},
+		{name: "valid interval on rss", widgetType: "rss", interval: 30 * time.Second},
+		{name: "valid interval on hacker-news", widgetType: "hacker-news", interval: 1 * time.Minute},
+		{name: "below minimum", widgetType: "rss", interval: 29 * time.Second, errContains: "at least 30s"},
+		{name: "disallowed: clock", widgetType: "clock", interval: 1 * time.Minute, errContains: `type "clock"`},
+		{name: "disallowed: calendar", widgetType: "calendar", interval: 1 * time.Minute, errContains: `type "calendar"`},
+		{name: "disallowed: to-do", widgetType: "to-do", interval: 1 * time.Minute, errContains: `type "to-do"`},
+		{name: "disallowed: iframe", widgetType: "iframe", interval: 1 * time.Minute, errContains: `type "iframe"`},
+		{name: "disallowed: html", widgetType: "html", interval: 1 * time.Minute, errContains: `type "html"`},
+		{name: "disallowed: group", widgetType: "group", interval: 1 * time.Minute, errContains: `type "group"`},
+		{name: "disallowed: split-column", widgetType: "split-column", interval: 1 * time.Minute, errContains: `type "split-column"`},
+		{name: "disallowed: search", widgetType: "search", interval: 1 * time.Minute, errContains: `type "search"`},
+		{name: "disallowed: bookmarks", widgetType: "bookmarks", interval: 1 * time.Minute, errContains: `type "bookmarks"`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := &widgetBase{Type: tc.widgetType, RefreshInterval: durationField(tc.interval)}
+			err := w.validate()
+			if tc.errContains == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.errContains)
+			}
+			if !strings.Contains(err.Error(), tc.errContains) {
+				t.Fatalf("expected error containing %q, got: %v", tc.errContains, err)
+			}
+		})
+	}
+}

--- a/internal/glance/widget_test.go
+++ b/internal/glance/widget_test.go
@@ -6,6 +6,32 @@ import (
 	"time"
 )
 
+func TestRegisterWidgetIncludesContainerChildren(t *testing.T) {
+	leaf1 := &clockWidget{}
+	leaf1.setID(101)
+	leaf2 := &clockWidget{}
+	leaf2.setID(102)
+	leaf3 := &clockWidget{}
+	leaf3.setID(103)
+
+	group := &groupWidget{}
+	group.setID(200)
+	group.containerWidgetBase.Widgets = widgets{leaf1, leaf2}
+
+	split := &splitColumnWidget{}
+	split.setID(300)
+	split.containerWidgetBase.Widgets = widgets{group, leaf3}
+
+	app := &application{widgetByID: make(map[uint64]widget)}
+	app.registerWidget(split)
+
+	for _, id := range []uint64{101, 102, 103, 200, 300} {
+		if _, ok := app.widgetByID[id]; !ok {
+			t.Errorf("widget id %d was not registered", id)
+		}
+	}
+}
+
 func TestWidgetValidateRefreshInterval(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/glance/widget_test.go
+++ b/internal/glance/widget_test.go
@@ -115,12 +115,12 @@ func TestWidgetValidateRefreshInterval(t *testing.T) {
 		interval    time.Duration
 		errContains string
 	}{
-		{name: "no interval is allowed on any type", widgetType: "clock", interval: 0},
-		{name: "valid interval on rss", widgetType: "rss", interval: 5 * time.Second},
-		{name: "valid interval on hacker-news", widgetType: "hacker-news", interval: 1 * time.Minute},
+		{name: "interval=0 skips disallow check", widgetType: "clock", interval: 0},
+		{name: "valid interval on allowed type", widgetType: "rss", interval: 5 * time.Second},
 		{name: "below minimum", widgetType: "rss", interval: 4 * time.Second, errContains: "at least 5s"},
 		{name: "disallowed: clock", widgetType: "clock", interval: 1 * time.Minute, errContains: `type "clock"`},
 		{name: "disallowed: calendar", widgetType: "calendar", interval: 1 * time.Minute, errContains: `type "calendar"`},
+		{name: "disallowed: calendar-legacy", widgetType: "calendar-legacy", interval: 1 * time.Minute, errContains: `type "calendar-legacy"`},
 		{name: "disallowed: to-do", widgetType: "to-do", interval: 1 * time.Minute, errContains: `type "to-do"`},
 		{name: "disallowed: iframe", widgetType: "iframe", interval: 1 * time.Minute, errContains: `type "iframe"`},
 		{name: "disallowed: html", widgetType: "html", interval: 1 * time.Minute, errContains: `type "html"`},

--- a/internal/glance/widget_test.go
+++ b/internal/glance/widget_test.go
@@ -14,9 +14,9 @@ func TestWidgetValidateRefreshInterval(t *testing.T) {
 		errContains string
 	}{
 		{name: "no interval is allowed on any type", widgetType: "clock", interval: 0},
-		{name: "valid interval on rss", widgetType: "rss", interval: 30 * time.Second},
+		{name: "valid interval on rss", widgetType: "rss", interval: 5 * time.Second},
 		{name: "valid interval on hacker-news", widgetType: "hacker-news", interval: 1 * time.Minute},
-		{name: "below minimum", widgetType: "rss", interval: 29 * time.Second, errContains: "at least 30s"},
+		{name: "below minimum", widgetType: "rss", interval: 4 * time.Second, errContains: "at least 5s"},
 		{name: "disallowed: clock", widgetType: "clock", interval: 1 * time.Minute, errContains: `type "clock"`},
 		{name: "disallowed: calendar", widgetType: "calendar", interval: 1 * time.Minute, errContains: `type "calendar"`},
 		{name: "disallowed: to-do", widgetType: "to-do", interval: 1 * time.Minute, errContains: `type "to-do"`},

--- a/internal/glance/widget_test.go
+++ b/internal/glance/widget_test.go
@@ -1,10 +1,34 @@
 package glance
 
 import (
+	"context"
+	"html/template"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+// stub widget that counts update() calls and respects the cache schedule.
+type counterWidget struct {
+	widgetBase
+	updates atomic.Int64
+}
+
+func (w *counterWidget) initialize() error {
+	w.withCacheDuration(time.Hour)
+	return nil
+}
+
+func (w *counterWidget) update(ctx context.Context) {
+	w.updates.Add(1)
+	// hold the lock long enough for sibling goroutines to pile up on it
+	time.Sleep(20 * time.Millisecond)
+	w.scheduleNextUpdate()
+}
+
+func (w *counterWidget) Render() template.HTML { return "" }
 
 func TestRegisterWidgetIncludesContainerChildren(t *testing.T) {
 	leaf1 := &clockWidget{}
@@ -29,6 +53,58 @@ func TestRegisterWidgetIncludesContainerChildren(t *testing.T) {
 		if _, ok := app.widgetByID[id]; !ok {
 			t.Errorf("widget id %d was not registered", id)
 		}
+	}
+}
+
+func TestUpdateOutdatedWidgetsDedupesConcurrentCalls(t *testing.T) {
+	w := &counterWidget{}
+	w.setID(1)
+	if err := w.initialize(); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &page{}
+	p.HeadWidgets = widgets{w}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p.updateOutdatedWidgets()
+		}()
+	}
+	wg.Wait()
+
+	if got := w.updates.Load(); got != 1 {
+		t.Errorf("expected 1 update across 10 concurrent page renders, got %d", got)
+	}
+}
+
+func TestContainerUpdateDedupesConcurrentCalls(t *testing.T) {
+	child := &counterWidget{}
+	child.setID(1)
+	if err := child.initialize(); err != nil {
+		t.Fatal(err)
+	}
+
+	group := &groupWidget{}
+	group.setID(2)
+	group.containerWidgetBase.Widgets = widgets{child}
+
+	var wg sync.WaitGroup
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			group.containerWidgetBase._update(ctx)
+		}()
+	}
+	wg.Wait()
+
+	if got := child.updates.Load(); got != 1 {
+		t.Errorf("expected 1 update across 10 concurrent container updates, got %d", got)
 	}
 }
 


### PR DESCRIPTION
Closes #327 (request).

This is a fresh take on per-widget refresh, written specifically around the two
concerns you raised on that issue and on #793:

> The front-end wasn't built in a way where you can unload/unmount anything, so
> refreshing individual widgets without reloading the entire page isn't possible
> currently.

> The `setupPage` function calls other functions, some of which add event
> listeners to the `window`/`document` and have no way of removing those
> listeners. If you simply call the `setupPage` function over and over, you're
> creating a memory leak…

> I'm not sure how a dedicated refresh button on the page is any different than
> just hitting the refresh button in your browser.

All are addressed below.

## What it does

- New `refresh-interval: <duration>` field on every widget. When set, the
  client polls `GET /api/widgets/{id}/refresh` on that interval and swaps the
  widget's `outerHTML` in place.
- The endpoint at `GET /api/widgets/{widget}/refresh` (the route was already
  reserved with a TODO comment in `glance.go`). `?force=1` bypasses the
  widget's cache; without it, a tick within the cache window just re-renders
  existing data (no upstream call). This is what the existing `cache:` field
  becomes useful for once you have client polling.
- A `validate()` call at config load rejects `refresh-interval` on widget
  types that hold interactive client state, embed external content, or have
  nothing to refetch (`calendar`, `to-do`, `clock`, `iframe`, `html`,
  `search`, `bookmarks`, `group`, `split-column`). Fails fast at config load
  rather than silently ignoring. Minimum 5s as a typo-floor.

## Addressing your concerns

### "the frontend wasn't built to unmount" — handled, no global lifecycle refactor

I deliberately did **not** introduce a generic widget lifecycle. Instead:

1. The `setupX()` functions in `page.js`, `popover.js`, `masonry.js` now
   accept an optional `root = document` argument. Existing call sites pass
   nothing and behave identically.
2. A small per-widget cleanup-callback registry (`_cleanupCallbacks` on the
   widget's root element) — only the three setups that bind to
   `window`/`document` or instantiate observers register a callback:
   `setupCarousels` (window resize listener), `setupCollapsibleGrids` and
   `setupMasonries` (`ResizeObserver`). All other setups bind to widget
   descendants and are released naturally when the old DOM is replaced.
3. `runWidgetCleanup(widgetEl)` runs those callbacks before `outerHTML` is
   swapped. The new node has its own fresh registry.
4. `setupDynamicRelativeTime` was the one global timer that captured a stale
   `elements` array — it now queries the document fresh on each tick and is
   initialized only once. Refreshed widgets are picked up automatically.
5. `afterContentReady` fires immediately when called post-init, so refresh-
   path setups don't queue forever.

I verified there's no listener accumulation by leaving a horizontal-cards RSS
widget refreshing for several cycles in a real browser and watching its
`_cleanupCallbacks` count — it stays at 1, not climbing.

### "many times more upstream requests" — the math doesn't actually pencil out that way

The whole mechanism is built around `cache:` being the rate limiter, not the
client interval:

- A client tick inside the cache window calls `requiresUpdate` → false →
  re-renders the existing buffer. **Zero upstream calls.**
- A client tick outside the cache window fires exactly one `update()`,
  serialized by the per-widget mutex (and re-checked inside the lock so two
  concurrent renders can't double-fire).

So with the typical RSS default of `cache: 1h` and `refresh-interval: 1m`,
that's 60 client ticks per hour producing 1 upstream call per hour — the
same call cadence you have today, just delivered to the browser without a
manual reload. The user has to set `cache:` to something tighter to actually
increase upstream traffic, which is the same lever that exists today.

### "only update while in foreground" — done

`visibilitychange` clears all interval handles when the tab is hidden and
reinstalls them on focus, with an immediate refresh if the interval already
elapsed during the hidden period. Tab in the background → zero requests.

### "should be per-widget basis" — done

Opt-in per widget, default off. Disallow list enforced at config load.

### "how is this different from a browser refresh?" — three things

- **Force-bypass the cache.** A browser refresh re-runs the page render but
  `requiresUpdate` short-circuits when the cache is fresh. You can't actually
  pull new data on demand without restarting the server. `?force=1` does.
- **Preserves page state.** Scroll, theme picker, popovers, expanded lists in
  *other* widgets, etc.
- **Per-widget intervals.** The whole point is that monitor / dns-stats /
  server-stats each have their own cadence without a page-wide reload that
  also refetches feeds and other slow widgets.

## Locking

The previously-stubbed `handleWidgetRequest` had a TODO calling out the
locking rework. That's the other half of the backend commit:

- `widgetBase` gets a `sync.Mutex`.
- `renderTemplate` takes the lock (covers all `.Render` paths via the
  shared `templateBuffer`).
- `updateOutdatedWidgets` and `containerWidgetBase._update` lock per-widget
  around `update(ctx)` and re-check `requiresUpdate` inside the lock so two
  concurrent page renders can't both fire the same upstream call.
- The page-level lock around `updateOutdatedWidgets` is removed (and the
  unused `page.mu` field with it).

`Render()` and `update()` don't recursively call each other in any widget
type, so re-entrance isn't a risk. Containers (group, split-column) don't
have their own mutex contention with children — different mutex objects.

## What's not in this PR

- No refresh button UI. Easy follow-up; deliberately out of scope so this PR
  stays focused on the mechanism.
- No persistence of cache across restarts.

## Test notes

- `TestWidgetValidateRefreshInterval` covers the disallow list, the
  minimum-interval floor, and the no-interval baseline.
- `TestRegisterWidgetIncludesContainerChildren` covers recursive
  registration of nested widgets.
- `TestUpdateOutdatedWidgetsDedupesConcurrentCalls` and
  `TestContainerUpdateDedupesConcurrentCalls` fire 10 concurrent renders
  against a counter-stub widget and assert exactly one `update()` fires —
  evidence that the locking scheme actually delivers the API politeness
  claim above.
- Existing tests all pass.
- Manually exercised in browser across: `hacker-news`, `rss` (list +
  horizontal-cards/carousel), `monitor`, `server-stats`, `dns-stats`,
  `custom-api`. Auto-refresh swaps cleanly, popovers and lazy-images keep
  working post-swap, console stays clean across cycles.
- Visibility pause: tab → background → no requests; tab → foreground → fires
  immediate refresh if interval elapsed.

Happy to split the PR, change naming, restructure the cleanup registry, or
rewrite the description — just let me know what fits the project's direction.
