### PR TITLE
docs: add Sealos one-click deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,23 +156,6 @@ pages:
 Choose one of the following methods:
 
 <details>
-<summary><strong>Deploy on Sealos</strong></summary>
-<br>
-
-[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/glance)
-
-Glance can be deployed with the maintained Sealos one-click template. The Sealos template defines the application resources, generated defaults, and storage settings in the Sealos templates repository at [`template/glance/index.yaml`](https://github.com/labring-actions/templates/blob/main/template/glance/index.yaml).
-
-Before deploying:
-* Review the generated template defaults and any user-provided inputs in Sealos.
-* Review persistence and storage settings in the Sealos template before storing production data.
-* After deployment, open the generated Sealos app URL and complete the application first-run setup or login flow.
-
-<hr>
-</details>
-
-
-<details>
 <summary><strong>Docker compose using provided directory structure (recommended)</strong></summary>
 <br>
 
@@ -287,6 +270,7 @@ Glance can also be installed through the following 3rd party channels:
 * [Proxmox VE Helper Script](https://community-scripts.github.io/ProxmoxVE/scripts?id=glance)
 * [NixOS package](https://search.nixos.org/packages?channel=unstable&show=glance)
 * [Coolify.io](https://coolify.io/docs/services/glance/)
+* [Sealos](docs/sealos.md)
 
 <hr>
 </details>

--- a/README.md
+++ b/README.md
@@ -156,6 +156,23 @@ pages:
 Choose one of the following methods:
 
 <details>
+<summary><strong>Deploy on Sealos</strong></summary>
+<br>
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/glance)
+
+Glance can be deployed with the maintained Sealos one-click template. The Sealos template defines the application resources, generated defaults, and storage settings in the Sealos templates repository at [`template/glance/index.yaml`](https://github.com/labring-actions/templates/blob/main/template/glance/index.yaml).
+
+Before deploying:
+* Review the generated template defaults and any user-provided inputs in Sealos.
+* Review persistence and storage settings in the Sealos template before storing production data.
+* After deployment, open the generated Sealos app URL and complete the application first-run setup or login flow.
+
+<hr>
+</details>
+
+
+<details>
 <summary><strong>Docker compose using provided directory structure (recommended)</strong></summary>
 <br>
 

--- a/docs/sealos.md
+++ b/docs/sealos.md
@@ -1,0 +1,25 @@
+# Deploying Glance on Sealos
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/glance)
+
+Sealos provides a maintained one-click template for deploying Glance. The template defines the application resources, generated defaults, and storage settings in the Sealos templates repository at [`template/glance/index.yaml`](https://github.com/labring-actions/templates/blob/main/template/glance/index.yaml).
+
+## Before deploying
+
+- Review the generated template defaults and any user-provided inputs in Sealos.
+- Review persistence and storage settings in the Sealos template before storing production data.
+- Keep your Glance configuration backed up so it can be reused if you later move to another installation method.
+
+## Deploy
+
+1. Open the [Glance template on Sealos](https://sealos.io/products/app-store/glance).
+2. Click **Deploy Now** and review the template settings.
+3. Start the deployment and wait for Sealos to create the application resources.
+4. Open the generated Sealos app URL.
+5. Complete any first-run setup or login flow required by your Glance configuration.
+
+## Updating configuration
+
+Glance is configured through YAML files. After deploying, update your configuration from the Sealos application resources and restart the application if the changed settings require a reload.
+
+For Glance configuration details, see [Configuring Glance](configuration.md).


### PR DESCRIPTION
## Summary

This PR adds Sealos as an optional third-party installation path for Glance.

## Why this is useful

- Lowers friction for self-hosting and evaluation
- Keeps existing manual deployment instructions intact
- Does not change runtime behavior for existing users

## What changed

- Added Sealos to the existing `Other` installation list, alongside entries such as Coolify.io
- Added a dedicated `docs/sealos.md` page with the Deploy on Sealos button and setup notes
- Linked to `https://sealos.io/products/app-store/glance`
- Documented template defaults, storage review, and post-deploy verification

## Reviewability

- Docs-only change
- No referral, affiliate, or tracking links
- Deployment definition is maintained in the Sealos templates repository at [`template/glance/index.yaml`](https://github.com/labring-actions/templates/blob/main/template/glance/index.yaml)
- Required inputs to review: generated template defaults and any user-provided inputs in Sealos
- Persistence/storage note: The template includes persistence/storage resources; reviewers should check the referenced template before production use.

## Validation

- Checked the Sealos App Store URL format
- Checked README, docs, and PR text for common secret and referral patterns
- Confirmed the docs mention inputs, persistence/storage, and post-deploy steps
