### PR TITLE
Fix Twitch StreamMetadata persisted query hash rotation

### DIFF
--- a/internal/glance/widget-twitch-channels.go
+++ b/internal/glance/widget-twitch-channels.go
@@ -121,7 +121,7 @@ type twitchStreamMetadataOperationResponse struct {
 
 const twitchChannelStatusOperationRequestBody = `[
 {"operationName":"ChannelShell","variables":{"login":"%s"},"extensions":{"persistedQuery":{"version":1,"sha256Hash":"580ab410bcd0c1ad194224957ae2241e5d252b2c5173d8e0cce9d32d5bb14efe"}}},
-{"operationName":"StreamMetadata","variables":{"channelLogin":"%s"},"extensions":{"persistedQuery":{"version":1,"sha256Hash":"676ee2f834ede42eb4514cdb432b3134fefc12590080c9a2c9bb44a2a4a63266"}}}
+{"operationName":"StreamMetadata","variables":{"channelLogin":"%s","includeIsDJ":true},"extensions":{"persistedQuery":{"version":1,"sha256Hash":"b57f9b910f8cd1a4659d894fe7550ccc81ec9052c01e438b290fd66a040b9b93"}}}
 ]`
 
 // TODO: rework


### PR DESCRIPTION
Twitch rotated the persisted query hash for StreamMetadata, causing the old hash to return PersistedQueryNotFound with no `data` field, which then triggered `json.Unmarshal(nil, ...)` -> "unexpected end of JSON input".
Fix was to update to the current hash sourced from streamlink which tracks Twitch GQL API changes.

Also added the required `includeIsDJ` variable, otherwise we get a `Variable \"includeIsDJ\" has invalid value null.\nExpected type \"Boolean!\", found null` error.

Verified by curling `https://gql.twitch.tv/gql` directly, old hash returns `PersistedQueryNotFound`, new hash returns valid stream metadata.

<!-- If your pull request adds new features, changes existing ones or fixes any bugs, please use the dev branch as the base, otherwise use the main branch -->
