### PR TITLE
Feature: Add OpenID Connect auth

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,7 +224,7 @@ For property descriptions, validation and autocompletion of the config within yo
 
 ## Authentication
 
-To make sure that only you and the people you want to share your dashboard with have access to it, you can set up authentication via username and password. This is done through a top level `auth` property. Example:
+To make sure that only you and the people you want to share your dashboard with have access to it, you can set up authentication via username and password or OpenID Connect (OIDC). This is done through a top level `auth` property. Example:
 
 ```yaml
 auth:
@@ -282,6 +282,74 @@ server:
 ```
 
 When set to `true`, Glance will use the `X-Forwarded-For` header to determine the original IP address of the request, so make sure that your reverse proxy is correctly configured to send that header.
+
+### OpenID Connect (OIDC)
+
+Glance can authenticate users through any OpenID Connect provider, such as Keycloak, PocketID, Authelia, or Google. When configured, users can sign in from the login page with a **Sign in with SSO** button. After the provider authenticates the user, Glance creates the same session cookie used by local authentication.
+
+Example:
+
+```yaml
+auth:
+  secret-key: # this must be set to a random value generated using the secret:make CLI command
+  oidc:
+    issuer: https://auth.example.com/realms/home
+    client-id: glance
+    client-secret: ${secret:oidc-client-secret}
+    username-claim: preferred_username
+```
+
+You can use OIDC on its own, together with local users, or keep a local break-glass account alongside SSO.
+
+Local login requires at least one entry under `auth.users`. Setting `disable-local-login: false` (the default) keeps the username/password form visible when local users are configured. Set `disable-local-login: true` to show only the SSO button.
+
+#### Redirect URI
+
+Register this redirect URI with your OIDC provider:
+
+```
+https://your-glance-host/auth/oidc/callback
+```
+
+If Glance is hosted under a subpath, include the base URL prefix:
+
+```
+https://your-glance-host/glance/auth/oidc/callback
+```
+
+If you need to override the automatically detected redirect URI, set `redirect-url` explicitly:
+
+```yaml
+auth:
+  oidc:
+    redirect-url: https://glance.example.com/auth/oidc/callback
+```
+
+When `redirect-url` is not set, Glance builds the redirect URI from the incoming request host, `X-Forwarded-Proto`, and `server.base-url`.
+
+#### OIDC properties
+
+| Name | Type | Required | Default |
+| ---- | ---- | -------- | ------- |
+| issuer | string | yes | |
+| client-id | string | yes | |
+| client-secret | string | yes | |
+| redirect-url | string | no | derived from request |
+| scopes | list of strings | no | `openid`, `profile`, `email` |
+| username-claim | string | no | `preferred_username`, then `email`, then `sub` |
+| auto-login | boolean | no | `false` |
+| disable-local-login | boolean | no | `false` |
+
+#### Provider notes
+
+| Provider | Example issuer | Suggested `username-claim` |
+| -------- | ---------------- | -------------------------- |
+| Keycloak | `https://keycloak.example.com/realms/home` | `preferred_username` |
+| PocketID | `https://pocketid.example.com` | `preferred_username` |
+| Authelia | `https://authelia.example.com` | `preferred_username` |
+| Google | `https://accounts.google.com` | `email` |
+
+When using a reverse proxy, set `server.proxied: true` so Glance can determine the client IP address and whether cookies should be marked secure.
 
 ## Server
 Server configuration is done through a top level `server` property. Example:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -296,8 +296,9 @@ auth:
     issuer: https://auth.example.com/realms/home
     client-id: glance
     client-secret: ${secret:oidc-client-secret}
-    username-claim: preferred_username
 ```
+
+Glance requests only the `openid` scope and uses the ID token's `sub` claim as the session identity. No extra scopes or claim mapping is required.
 
 You can use OIDC on its own, together with local users, or keep a local break-glass account alongside SSO.
 
@@ -335,19 +336,17 @@ When `redirect-url` is not set, Glance builds the redirect URI from the incoming
 | client-id | string | yes | |
 | client-secret | string | yes | |
 | redirect-url | string | no | derived from request |
-| scopes | list of strings | no | `openid`, `profile`, `email` |
-| username-claim | string | no | `preferred_username`, then `email`, then `sub` |
 | auto-login | boolean | no | `false` |
 | disable-local-login | boolean | no | `false` |
 
 #### Provider notes
 
-| Provider | Example issuer | Suggested `username-claim` |
-| -------- | ---------------- | -------------------------- |
-| Keycloak | `https://keycloak.example.com/realms/home` | `preferred_username` |
-| PocketID | `https://pocketid.example.com` | `preferred_username` |
-| Authelia | `https://authelia.example.com` | `preferred_username` |
-| Google | `https://accounts.google.com` | `email` |
+| Provider | Example issuer |
+| -------- | ---------------- |
+| Keycloak | `https://keycloak.example.com/realms/home` |
+| PocketID | `https://pocketid.example.com` |
+| Authelia | `https://authelia.example.com` |
+| Google | `https://accounts.google.com` |
 
 When using a reverse proxy, set `server.proxied: true` so Glance can determine the client IP address and whether cookies should be marked secure.
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/glanceapp/glance
 go 1.26.3
 
 require (
+	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/mmcdole/gofeed v1.3.0
 	github.com/refraction-networking/utls v1.8.2
@@ -10,6 +11,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	golang.org/x/crypto v0.38.0
 	golang.org/x/net v0.40.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/text v0.25.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -18,7 +20,6 @@ require (
 	github.com/PuerkitoBio/goquery v1.10.3 // indirect
 	github.com/andybalholm/brotli v1.0.6 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
-	github.com/coreos/go-oidc/v3 v3.18.0 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
@@ -34,6 +35,5 @@ require (
 	github.com/tklauser/go-sysconf v0.3.15 // indirect
 	github.com/tklauser/numcpus v0.10.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,9 @@ require (
 	github.com/PuerkitoBio/goquery v1.10.3 // indirect
 	github.com/andybalholm/brotli v1.0.6 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
+	github.com/coreos/go-oidc/v3 v3.18.0 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
@@ -32,5 +34,6 @@ require (
 	github.com/tklauser/go-sysconf v0.3.15 // indirect
 	github.com/tklauser/numcpus v0.10.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/andybalholm/brotli v1.0.6 h1:Yf9fFpf49Zrxb9NlQaluyE92/+X7UVHlhMNJN2sx
 github.com/andybalholm/brotli v1.0.6/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
+github.com/coreos/go-oidc/v3 v3.18.0 h1:V9orjXynvu5wiC9SemFTWnG4F45v403aIcjWo0d41+A=
+github.com/coreos/go-oidc/v3 v3.18.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -11,6 +13,8 @@ github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0o
 github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
@@ -83,6 +87,8 @@ golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
 golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/net v0.40.0 h1:79Xs7wF06Gbdcg4kdCCIQArK11Z1hr5POQ6+fIYHNuY=
 golang.org/x/net v0.40.0/go.mod h1:y0hY0exeL2Pku80/zKK7tpntoX23cqL3Oa6njdgRtds=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/glance/auth.go
+++ b/internal/glance/auth.go
@@ -49,6 +49,65 @@ type failedAuthAttempt struct {
 	first    time.Time
 }
 
+func requestIsHTTPS(r *http.Request) bool {
+	return strings.ToLower(r.Header.Get("X-Forwarded-Proto")) == "https"
+}
+
+func (a *application) newAuthCookie(r *http.Request, name, value string, expires time.Time) *http.Cookie {
+	return &http.Cookie{
+		Name:     name,
+		Value:    value,
+		Expires:  expires,
+		Secure:   requestIsHTTPS(r),
+		Path:     a.Config.Server.BaseURL + "/",
+		SameSite: http.SameSiteLaxMode,
+		HttpOnly: true,
+	}
+}
+
+func (a *application) cleanupStaleAuthAttempts() {
+	for ip := range a.failedAuthAttempts {
+		if time.Since(a.failedAuthAttempts[ip].first) > AUTH_RATE_LIMIT_WINDOW {
+			delete(a.failedAuthAttempts, ip)
+		}
+	}
+}
+
+func (a *application) beginAuthAttempt(ip string) (exceeded bool, retryAfter int) {
+	attempt, exists := a.failedAuthAttempts[ip]
+	if !exists {
+		a.failedAuthAttempts[ip] = &failedAuthAttempt{
+			attempts: 1,
+			first:    time.Now(),
+		}
+		a.cleanupStaleAuthAttempts()
+		return false, 0
+	}
+
+	elapsed := time.Since(attempt.first)
+	if elapsed < AUTH_RATE_LIMIT_WINDOW && attempt.attempts >= AUTH_RATE_LIMIT_MAX_ATTEMPTS {
+		return true, max(1, int(AUTH_RATE_LIMIT_WINDOW.Seconds()-elapsed.Seconds()))
+	}
+
+	attempt.attempts++
+	a.cleanupStaleAuthAttempts()
+	return false, 0
+}
+
+func (a *application) clearAuthAttempts(ip string) {
+	a.authAttemptsMu.Lock()
+	delete(a.failedAuthAttempts, ip)
+	a.authAttemptsMu.Unlock()
+}
+
+func (a *application) usernameForHash(hash string) (string, bool) {
+	a.usernameHashMu.RLock()
+	defer a.usernameHashMu.RUnlock()
+
+	username, ok := a.usernameHashToUsername[hash]
+	return username, ok
+}
+
 func generateSessionToken(username string, secret []byte, now time.Time) (string, error) {
 	if len(secret) != AUTH_SECRET_KEY_LENGTH {
 		return "", fmt.Errorf("secret key length is not %d bytes", AUTH_SECRET_KEY_LENGTH)
@@ -142,40 +201,14 @@ func (a *application) handleAuthenticationAttempt(w http.ResponseWriter, r *http
 	ip := a.addressOfRequest(r)
 
 	a.authAttemptsMu.Lock()
-	exceededRateLimit, retryAfter := func() (bool, int) {
-		attempt, exists := a.failedAuthAttempts[ip]
-		if !exists {
-			a.failedAuthAttempts[ip] = &failedAuthAttempt{
-				attempts: 1,
-				first:    time.Now(),
-			}
-
-			return false, 0
-		}
-
-		elapsed := time.Since(attempt.first)
-		if elapsed < AUTH_RATE_LIMIT_WINDOW && attempt.attempts >= AUTH_RATE_LIMIT_MAX_ATTEMPTS {
-			return true, max(1, int(AUTH_RATE_LIMIT_WINDOW.Seconds()-elapsed.Seconds()))
-		}
-
-		attempt.attempts++
-		return false, 0
-	}()
+	exceededRateLimit, retryAfter := a.beginAuthAttempt(ip)
+	a.authAttemptsMu.Unlock()
 
 	if exceededRateLimit {
-		a.authAttemptsMu.Unlock()
 		time.Sleep(waitOnFailure)
 		w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 		w.WriteHeader(http.StatusTooManyRequests)
 		return
-	} else {
-		// Clean up old failed attempts
-		for ipOfAttempt := range a.failedAuthAttempts {
-			if time.Since(a.failedAuthAttempts[ipOfAttempt].first) > AUTH_RATE_LIMIT_WINDOW {
-				delete(a.failedAuthAttempts, ipOfAttempt)
-			}
-		}
-		a.authAttemptsMu.Unlock()
 	}
 
 	body, err := io.ReadAll(r.Body)
@@ -240,9 +273,7 @@ func (a *application) handleAuthenticationAttempt(w http.ResponseWriter, r *http
 
 	a.setAuthSessionCookie(w, r, token, time.Now().Add(AUTH_TOKEN_VALID_PERIOD))
 
-	a.authAttemptsMu.Lock()
-	delete(a.failedAuthAttempts, ip)
-	a.authAttemptsMu.Unlock()
+	a.clearAuthAttempts(ip)
 
 	w.WriteHeader(http.StatusOK)
 }
@@ -262,13 +293,12 @@ func (a *application) isAuthorized(w http.ResponseWriter, r *http.Request) bool 
 		return false
 	}
 
-	username, exists := a.usernameHashToUsername[string(usernameHash)]
+	username, exists := a.usernameForHash(string(usernameHash))
 	if !exists {
 		return false
 	}
 
-	_, exists = a.Config.Auth.Users[username]
-	if !exists && !a.isOIDCUser(username) {
+	if _, localUser := a.Config.Auth.Users[username]; !localUser && !a.oidcEnabled {
 		return false
 	}
 
@@ -309,15 +339,7 @@ func (a *application) handleLogoutRequest(w http.ResponseWriter, r *http.Request
 }
 
 func (a *application) setAuthSessionCookie(w http.ResponseWriter, r *http.Request, token string, expires time.Time) {
-	http.SetCookie(w, &http.Cookie{
-		Name:     AUTH_SESSION_COOKIE_NAME,
-		Value:    token,
-		Expires:  expires,
-		Secure:   strings.ToLower(r.Header.Get("X-Forwarded-Proto")) == "https",
-		Path:     a.Config.Server.BaseURL + "/",
-		SameSite: http.SameSiteLaxMode,
-		HttpOnly: true,
-	})
+	http.SetCookie(w, a.newAuthCookie(r, AUTH_SESSION_COOKIE_NAME, token, expires))
 }
 
 func (a *application) handleLoginPageRequest(w http.ResponseWriter, r *http.Request) {
@@ -326,14 +348,15 @@ func (a *application) handleLoginPageRequest(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if a.oidcEnabled && a.Config.Auth.OIDC.AutoLogin && !a.showLocalLoginForm() {
+	showLocalLogin := a.showLocalLoginForm()
+	if a.oidcEnabled && a.Config.Auth.OIDC.AutoLogin && !showLocalLogin {
 		a.handleOIDCLogin(w, r)
 		return
 	}
 
 	data := &templateData{
 		App:            a,
-		ShowLocalLogin: a.showLocalLoginForm(),
+		ShowLocalLogin: showLocalLogin,
 		ShowOIDCLogin:  a.oidcEnabled,
 	}
 	a.populateTemplateRequestData(&data.Request, r)

--- a/internal/glance/auth.go
+++ b/internal/glance/auth.go
@@ -268,7 +268,7 @@ func (a *application) isAuthorized(w http.ResponseWriter, r *http.Request) bool 
 	}
 
 	_, exists = a.Config.Auth.Users[username]
-	if !exists {
+	if !exists && !a.isOIDCUser(username) {
 		return false
 	}
 
@@ -326,8 +326,15 @@ func (a *application) handleLoginPageRequest(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	if a.oidcEnabled && a.Config.Auth.OIDC.AutoLogin && !a.showLocalLoginForm() {
+		a.handleOIDCLogin(w, r)
+		return
+	}
+
 	data := &templateData{
-		App: a,
+		App:            a,
+		ShowLocalLogin: a.showLocalLoginForm(),
+		ShowOIDCLogin:  a.oidcEnabled,
 	}
 	a.populateTemplateRequestData(&data.Request, r)
 

--- a/internal/glance/auth_oidc.go
+++ b/internal/glance/auth_oidc.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -22,9 +21,13 @@ const (
 	OIDC_STATE_COOKIE_NAME   = "oidc_state"
 	OIDC_STATE_VALID_PERIOD  = 10 * time.Minute
 	OIDC_STATE_MAX_DATA_SIZE = 2048
+	oidcLoginErrorParam      = "oidc"
 )
 
-var defaultOIDCScopes = []string{oidc.ScopeOpenID, "profile", "email"}
+var (
+	defaultOIDCScopes         = []string{oidc.ScopeOpenID, "profile", "email"}
+	defaultOIDCUsernameClaims = []string{"preferred_username", "email", "sub"}
+)
 
 type oidcFlowState struct {
 	State        string `json:"state"`
@@ -59,14 +62,9 @@ func (a *application) initOIDCAuth() error {
 		Endpoint:     provider.Endpoint(),
 		Scopes:       scopes,
 	}
-	a.oidcUsernames = make(map[string]struct{})
 	a.oidcEnabled = true
 
 	return nil
-}
-
-func (a *application) OIDCAuthEnabled() bool {
-	return a.oidcEnabled
 }
 
 func (a *application) LocalAuthEnabled() bool {
@@ -83,7 +81,7 @@ func (a *application) oidcRedirectURL(r *http.Request) string {
 	}
 
 	scheme := "http"
-	if strings.ToLower(r.Header.Get("X-Forwarded-Proto")) == "https" {
+	if requestIsHTTPS(r) {
 		scheme = "https"
 	}
 
@@ -96,16 +94,9 @@ func (a *application) handleOIDCLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	state, err := randomOIDCString(32)
+	state, nonce, err := randomOIDCStrings(2, 32)
 	if err != nil {
 		log.Printf("Could not generate oidc state: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-
-	nonce, err := randomOIDCString(32)
-	if err != nil {
-		log.Printf("Could not generate oidc nonce: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
@@ -146,37 +137,37 @@ func (a *application) handleOIDCCallback(w http.ResponseWriter, r *http.Request)
 
 	ip := a.addressOfRequest(r)
 
-	if a.recordOIDCAuthFailure(ip) {
+	a.authAttemptsMu.Lock()
+	exceededRateLimit, _ := a.beginAuthAttempt(ip)
+	a.authAttemptsMu.Unlock()
+
+	if exceededRateLimit {
 		a.redirectOIDCLoginError(w, r)
 		return
 	}
 
 	flowState, err := a.readOIDCStateCookie(r)
 	if err != nil {
-		log.Printf("Invalid oidc state cookie from %s: %v", ip, err)
+		a.failOIDCCallback(w, r, "Invalid oidc state cookie from %s: %v", ip, err)
 		a.clearOIDCStateCookie(w, r)
-		a.redirectOIDCLoginError(w, r)
 		return
 	}
 
 	a.clearOIDCStateCookie(w, r)
 
 	if r.URL.Query().Get("state") != flowState.State {
-		log.Printf("Mismatched oidc state from %s", ip)
-		a.redirectOIDCLoginError(w, r)
+		a.failOIDCCallback(w, r, "Mismatched oidc state from %s", ip)
 		return
 	}
 
 	if errMsg := r.URL.Query().Get("error"); errMsg != "" {
-		log.Printf("OIDC provider returned error for %s: %s (%s)", ip, errMsg, r.URL.Query().Get("error_description"))
-		a.redirectOIDCLoginError(w, r)
+		a.failOIDCCallback(w, r, "OIDC provider returned error for %s: %s (%s)", ip, errMsg, r.URL.Query().Get("error_description"))
 		return
 	}
 
 	code := r.URL.Query().Get("code")
 	if code == "" {
-		log.Printf("Missing oidc authorization code from %s", ip)
-		a.redirectOIDCLoginError(w, r)
+		a.failOIDCCallback(w, r, "Missing oidc authorization code from %s", ip)
 		return
 	}
 
@@ -192,81 +183,71 @@ func (a *application) handleOIDCCallback(w http.ResponseWriter, r *http.Request)
 		oauth2.VerifierOption(flowState.CodeVerifier),
 	)
 	if err != nil {
-		log.Printf("Could not exchange oidc code from %s: %v", ip, err)
-		a.redirectOIDCLoginError(w, r)
+		a.failOIDCCallback(w, r, "Could not exchange oidc code from %s: %v", ip, err)
 		return
 	}
 
 	rawIDToken, ok := token.Extra("id_token").(string)
 	if !ok || rawIDToken == "" {
-		log.Printf("Missing id_token in oidc response for %s", ip)
-		a.redirectOIDCLoginError(w, r)
+		a.failOIDCCallback(w, r, "Missing id_token in oidc response for %s", ip)
 		return
 	}
 
 	idToken, err := a.oidcVerifier.Verify(ctx, rawIDToken)
 	if err != nil {
-		log.Printf("Could not verify oidc id token from %s: %v", ip, err)
-		a.redirectOIDCLoginError(w, r)
+		a.failOIDCCallback(w, r, "Could not verify oidc id token from %s: %v", ip, err)
 		return
 	}
 
 	if idToken.Nonce != flowState.Nonce {
-		log.Printf("Mismatched oidc nonce from %s", ip)
-		a.redirectOIDCLoginError(w, r)
+		a.failOIDCCallback(w, r, "Mismatched oidc nonce from %s", ip)
 		return
 	}
 
 	username, err := usernameFromOIDCToken(idToken, a.Config.Auth.OIDC.UsernameClaim)
 	if err != nil {
-		log.Printf("Could not resolve oidc username from %s: %v", ip, err)
-		a.redirectOIDCLoginError(w, r)
+		a.failOIDCCallback(w, r, "Could not resolve oidc username from %s: %v", ip, err)
 		return
 	}
 
 	if err := a.registerOIDCUser(username); err != nil {
-		log.Printf("Could not register oidc user %q from %s: %v", username, ip, err)
-		a.redirectOIDCLoginError(w, r)
+		a.failOIDCCallback(w, r, "Could not register oidc user %q from %s: %v", username, ip, err)
 		return
 	}
 
 	sessionToken, err := generateSessionToken(username, a.authSecretKey, time.Now())
 	if err != nil {
-		log.Printf("Could not compute session token for oidc user %q: %v", username, err)
-		a.redirectOIDCLoginError(w, r)
+		a.failOIDCCallback(w, r, "Could not compute session token for oidc user %q: %v", username, err)
 		return
 	}
 
 	a.setAuthSessionCookie(w, r, sessionToken, time.Now().Add(AUTH_TOKEN_VALID_PERIOD))
-
-	a.authAttemptsMu.Lock()
-	delete(a.failedAuthAttempts, ip)
-	a.authAttemptsMu.Unlock()
+	a.clearAuthAttempts(ip)
 
 	http.Redirect(w, r, a.Config.Server.BaseURL+"/", http.StatusSeeOther)
 }
 
 func (a *application) registerOIDCUser(username string) error {
+	if _, ok := a.Config.Auth.Users[username]; ok {
+		return nil
+	}
+
 	usernameHash, err := computeUsernameHash(username, a.authSecretKey)
 	if err != nil {
 		return err
 	}
 
-	a.oidcUsernamesMu.Lock()
-	defer a.oidcUsernamesMu.Unlock()
+	hashKey := string(usernameHash)
 
-	a.usernameHashToUsername[string(usernameHash)] = username
-	a.oidcUsernames[username] = struct{}{}
+	a.usernameHashMu.Lock()
+	defer a.usernameHashMu.Unlock()
 
+	if _, ok := a.usernameHashToUsername[hashKey]; ok {
+		return nil
+	}
+
+	a.usernameHashToUsername[hashKey] = username
 	return nil
-}
-
-func (a *application) isOIDCUser(username string) bool {
-	a.oidcUsernamesMu.RLock()
-	defer a.oidcUsernamesMu.RUnlock()
-
-	_, ok := a.oidcUsernames[username]
-	return ok
 }
 
 func usernameFromOIDCToken(idToken *oidc.IDToken, usernameClaim string) (string, error) {
@@ -275,6 +256,10 @@ func usernameFromOIDCToken(idToken *oidc.IDToken, usernameClaim string) (string,
 		return "", err
 	}
 
+	return usernameFromClaims(claims, usernameClaim)
+}
+
+func usernameFromClaims(claims map[string]any, usernameClaim string) (string, error) {
 	if usernameClaim != "" {
 		username, ok := stringClaim(claims, usernameClaim)
 		if !ok {
@@ -283,7 +268,7 @@ func usernameFromOIDCToken(idToken *oidc.IDToken, usernameClaim string) (string,
 		return username, nil
 	}
 
-	for _, claim := range []string{"preferred_username", "email", "sub"} {
+	for _, claim := range defaultOIDCUsernameClaims {
 		if username, ok := stringClaim(claims, claim); ok {
 			return username, nil
 		}
@@ -306,42 +291,28 @@ func stringClaim(claims map[string]any, name string) (string, bool) {
 	return claim, true
 }
 
-func (a *application) recordOIDCAuthFailure(ip string) bool {
-	a.authAttemptsMu.Lock()
-	defer a.authAttemptsMu.Unlock()
-
-	attempt, exists := a.failedAuthAttempts[ip]
-	if !exists {
-		a.failedAuthAttempts[ip] = &failedAuthAttempt{
-			attempts: 1,
-			first:    time.Now(),
-		}
-		return false
-	}
-
-	elapsed := time.Since(attempt.first)
-	if elapsed >= AUTH_RATE_LIMIT_WINDOW {
-		a.failedAuthAttempts[ip] = &failedAuthAttempt{
-			attempts: 1,
-			first:    time.Now(),
-		}
-		return false
-	}
-
-	attempt.attempts++
-	return attempt.attempts > AUTH_RATE_LIMIT_MAX_ATTEMPTS
+func (a *application) failOIDCCallback(w http.ResponseWriter, r *http.Request, format string, args ...any) {
+	log.Printf(format, args...)
+	a.redirectOIDCLoginError(w, r)
 }
 
 func (a *application) redirectOIDCLoginError(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, a.Config.Server.BaseURL+"/login?error=oidc", http.StatusSeeOther)
+	http.Redirect(w, r, a.Config.Server.BaseURL+"/login?error="+oidcLoginErrorParam, http.StatusSeeOther)
 }
 
-func randomOIDCString(size int) (string, error) {
-	bytes := make([]byte, size)
+func randomOIDCStrings(count, size int) (string, string, error) {
+	bytes := make([]byte, size*count)
 	if _, err := rand.Read(bytes); err != nil {
-		return "", err
+		return "", "", err
 	}
-	return base64.RawURLEncoding.EncodeToString(bytes), nil
+
+	first := base64.RawURLEncoding.EncodeToString(bytes[0:size])
+	if count == 1 {
+		return first, "", nil
+	}
+
+	second := base64.RawURLEncoding.EncodeToString(bytes[size:])
+	return first, second, nil
 }
 
 func (a *application) setOIDCStateCookie(w http.ResponseWriter, r *http.Request, flowState oidcFlowState) error {
@@ -363,16 +334,7 @@ func (a *application) setOIDCStateCookie(w http.ResponseWriter, r *http.Request,
 	h.Write(data)
 	signed := base64.StdEncoding.EncodeToString(append(data, h.Sum(nil)...))
 
-	http.SetCookie(w, &http.Cookie{
-		Name:     OIDC_STATE_COOKIE_NAME,
-		Value:    signed,
-		Expires:  expires,
-		Secure:   strings.ToLower(r.Header.Get("X-Forwarded-Proto")) == "https",
-		Path:     a.Config.Server.BaseURL + "/",
-		SameSite: http.SameSiteLaxMode,
-		HttpOnly: true,
-	})
-
+	http.SetCookie(w, a.newAuthCookie(r, OIDC_STATE_COOKIE_NAME, signed, expires))
 	return nil
 }
 
@@ -425,13 +387,5 @@ func (a *application) readOIDCStateCookie(r *http.Request) (oidcFlowState, error
 }
 
 func (a *application) clearOIDCStateCookie(w http.ResponseWriter, r *http.Request) {
-	http.SetCookie(w, &http.Cookie{
-		Name:     OIDC_STATE_COOKIE_NAME,
-		Value:    "",
-		Expires:  time.Now().Add(-1 * time.Hour),
-		Secure:   strings.ToLower(r.Header.Get("X-Forwarded-Proto")) == "https",
-		Path:     a.Config.Server.BaseURL + "/",
-		SameSite: http.SameSiteLaxMode,
-		HttpOnly: true,
-	})
+	http.SetCookie(w, a.newAuthCookie(r, OIDC_STATE_COOKIE_NAME, "", time.Now().Add(-1*time.Hour)))
 }

--- a/internal/glance/auth_oidc.go
+++ b/internal/glance/auth_oidc.go
@@ -1,0 +1,437 @@
+package glance
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+)
+
+const (
+	OIDC_STATE_COOKIE_NAME   = "oidc_state"
+	OIDC_STATE_VALID_PERIOD  = 10 * time.Minute
+	OIDC_STATE_MAX_DATA_SIZE = 2048
+)
+
+var defaultOIDCScopes = []string{oidc.ScopeOpenID, "profile", "email"}
+
+type oidcFlowState struct {
+	State        string `json:"state"`
+	Nonce        string `json:"nonce"`
+	CodeVerifier string `json:"code_verifier"`
+	RedirectURL  string `json:"redirect_url"`
+}
+
+func (a *application) initOIDCAuth() error {
+	oidcConfig := a.Config.Auth.OIDC
+	if oidcConfig.Issuer == "" {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	provider, err := oidc.NewProvider(ctx, oidcConfig.Issuer)
+	if err != nil {
+		return fmt.Errorf("initializing oidc provider: %w", err)
+	}
+
+	scopes := oidcConfig.Scopes
+	if len(scopes) == 0 {
+		scopes = defaultOIDCScopes
+	}
+
+	a.oidcVerifier = provider.Verifier(&oidc.Config{ClientID: oidcConfig.ClientID})
+	a.oauth2Config = &oauth2.Config{
+		ClientID:     oidcConfig.ClientID,
+		ClientSecret: oidcConfig.ClientSecret,
+		Endpoint:     provider.Endpoint(),
+		Scopes:       scopes,
+	}
+	a.oidcUsernames = make(map[string]struct{})
+	a.oidcEnabled = true
+
+	return nil
+}
+
+func (a *application) OIDCAuthEnabled() bool {
+	return a.oidcEnabled
+}
+
+func (a *application) LocalAuthEnabled() bool {
+	return len(a.Config.Auth.Users) > 0
+}
+
+func (a *application) showLocalLoginForm() bool {
+	return a.LocalAuthEnabled() && !a.Config.Auth.OIDC.DisableLocalLogin
+}
+
+func (a *application) oidcRedirectURL(r *http.Request) string {
+	if a.Config.Auth.OIDC.RedirectURL != "" {
+		return a.Config.Auth.OIDC.RedirectURL
+	}
+
+	scheme := "http"
+	if strings.ToLower(r.Header.Get("X-Forwarded-Proto")) == "https" {
+		scheme = "https"
+	}
+
+	return scheme + "://" + r.Host + a.Config.Server.BaseURL + "/auth/oidc/callback"
+}
+
+func (a *application) handleOIDCLogin(w http.ResponseWriter, r *http.Request) {
+	if !a.oidcEnabled {
+		http.NotFound(w, r)
+		return
+	}
+
+	state, err := randomOIDCString(32)
+	if err != nil {
+		log.Printf("Could not generate oidc state: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	nonce, err := randomOIDCString(32)
+	if err != nil {
+		log.Printf("Could not generate oidc nonce: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	codeVerifier := oauth2.GenerateVerifier()
+	redirectURL := a.oidcRedirectURL(r)
+
+	flowState := oidcFlowState{
+		State:        state,
+		Nonce:        nonce,
+		CodeVerifier: codeVerifier,
+		RedirectURL:  redirectURL,
+	}
+
+	if err := a.setOIDCStateCookie(w, r, flowState); err != nil {
+		log.Printf("Could not set oidc state cookie: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	oauth2Config := *a.oauth2Config
+	oauth2Config.RedirectURL = redirectURL
+
+	authURL := oauth2Config.AuthCodeURL(
+		state,
+		oidc.Nonce(nonce),
+		oauth2.S256ChallengeOption(codeVerifier),
+	)
+
+	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+func (a *application) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
+	if !a.oidcEnabled {
+		http.NotFound(w, r)
+		return
+	}
+
+	ip := a.addressOfRequest(r)
+
+	if a.recordOIDCAuthFailure(ip) {
+		a.redirectOIDCLoginError(w, r)
+		return
+	}
+
+	flowState, err := a.readOIDCStateCookie(r)
+	if err != nil {
+		log.Printf("Invalid oidc state cookie from %s: %v", ip, err)
+		a.clearOIDCStateCookie(w, r)
+		a.redirectOIDCLoginError(w, r)
+		return
+	}
+
+	a.clearOIDCStateCookie(w, r)
+
+	if r.URL.Query().Get("state") != flowState.State {
+		log.Printf("Mismatched oidc state from %s", ip)
+		a.redirectOIDCLoginError(w, r)
+		return
+	}
+
+	if errMsg := r.URL.Query().Get("error"); errMsg != "" {
+		log.Printf("OIDC provider returned error for %s: %s (%s)", ip, errMsg, r.URL.Query().Get("error_description"))
+		a.redirectOIDCLoginError(w, r)
+		return
+	}
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		log.Printf("Missing oidc authorization code from %s", ip)
+		a.redirectOIDCLoginError(w, r)
+		return
+	}
+
+	oauth2Config := *a.oauth2Config
+	oauth2Config.RedirectURL = flowState.RedirectURL
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	token, err := oauth2Config.Exchange(
+		ctx,
+		code,
+		oauth2.VerifierOption(flowState.CodeVerifier),
+	)
+	if err != nil {
+		log.Printf("Could not exchange oidc code from %s: %v", ip, err)
+		a.redirectOIDCLoginError(w, r)
+		return
+	}
+
+	rawIDToken, ok := token.Extra("id_token").(string)
+	if !ok || rawIDToken == "" {
+		log.Printf("Missing id_token in oidc response for %s", ip)
+		a.redirectOIDCLoginError(w, r)
+		return
+	}
+
+	idToken, err := a.oidcVerifier.Verify(ctx, rawIDToken)
+	if err != nil {
+		log.Printf("Could not verify oidc id token from %s: %v", ip, err)
+		a.redirectOIDCLoginError(w, r)
+		return
+	}
+
+	if idToken.Nonce != flowState.Nonce {
+		log.Printf("Mismatched oidc nonce from %s", ip)
+		a.redirectOIDCLoginError(w, r)
+		return
+	}
+
+	username, err := usernameFromOIDCToken(idToken, a.Config.Auth.OIDC.UsernameClaim)
+	if err != nil {
+		log.Printf("Could not resolve oidc username from %s: %v", ip, err)
+		a.redirectOIDCLoginError(w, r)
+		return
+	}
+
+	if err := a.registerOIDCUser(username); err != nil {
+		log.Printf("Could not register oidc user %q from %s: %v", username, ip, err)
+		a.redirectOIDCLoginError(w, r)
+		return
+	}
+
+	sessionToken, err := generateSessionToken(username, a.authSecretKey, time.Now())
+	if err != nil {
+		log.Printf("Could not compute session token for oidc user %q: %v", username, err)
+		a.redirectOIDCLoginError(w, r)
+		return
+	}
+
+	a.setAuthSessionCookie(w, r, sessionToken, time.Now().Add(AUTH_TOKEN_VALID_PERIOD))
+
+	a.authAttemptsMu.Lock()
+	delete(a.failedAuthAttempts, ip)
+	a.authAttemptsMu.Unlock()
+
+	http.Redirect(w, r, a.Config.Server.BaseURL+"/", http.StatusSeeOther)
+}
+
+func (a *application) registerOIDCUser(username string) error {
+	usernameHash, err := computeUsernameHash(username, a.authSecretKey)
+	if err != nil {
+		return err
+	}
+
+	a.oidcUsernamesMu.Lock()
+	defer a.oidcUsernamesMu.Unlock()
+
+	a.usernameHashToUsername[string(usernameHash)] = username
+	a.oidcUsernames[username] = struct{}{}
+
+	return nil
+}
+
+func (a *application) isOIDCUser(username string) bool {
+	a.oidcUsernamesMu.RLock()
+	defer a.oidcUsernamesMu.RUnlock()
+
+	_, ok := a.oidcUsernames[username]
+	return ok
+}
+
+func usernameFromOIDCToken(idToken *oidc.IDToken, usernameClaim string) (string, error) {
+	var claims map[string]any
+	if err := idToken.Claims(&claims); err != nil {
+		return "", err
+	}
+
+	if usernameClaim != "" {
+		username, ok := stringClaim(claims, usernameClaim)
+		if !ok {
+			return "", fmt.Errorf("username claim %q is missing or empty", usernameClaim)
+		}
+		return username, nil
+	}
+
+	for _, claim := range []string{"preferred_username", "email", "sub"} {
+		if username, ok := stringClaim(claims, claim); ok {
+			return username, nil
+		}
+	}
+
+	return "", fmt.Errorf("no usable username claim found in id token")
+}
+
+func stringClaim(claims map[string]any, name string) (string, bool) {
+	value, ok := claims[name]
+	if !ok {
+		return "", false
+	}
+
+	claim, ok := value.(string)
+	if !ok || claim == "" {
+		return "", false
+	}
+
+	return claim, true
+}
+
+func (a *application) recordOIDCAuthFailure(ip string) bool {
+	a.authAttemptsMu.Lock()
+	defer a.authAttemptsMu.Unlock()
+
+	attempt, exists := a.failedAuthAttempts[ip]
+	if !exists {
+		a.failedAuthAttempts[ip] = &failedAuthAttempt{
+			attempts: 1,
+			first:    time.Now(),
+		}
+		return false
+	}
+
+	elapsed := time.Since(attempt.first)
+	if elapsed >= AUTH_RATE_LIMIT_WINDOW {
+		a.failedAuthAttempts[ip] = &failedAuthAttempt{
+			attempts: 1,
+			first:    time.Now(),
+		}
+		return false
+	}
+
+	attempt.attempts++
+	return attempt.attempts > AUTH_RATE_LIMIT_MAX_ATTEMPTS
+}
+
+func (a *application) redirectOIDCLoginError(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, a.Config.Server.BaseURL+"/login?error=oidc", http.StatusSeeOther)
+}
+
+func randomOIDCString(size int) (string, error) {
+	bytes := make([]byte, size)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(bytes), nil
+}
+
+func (a *application) setOIDCStateCookie(w http.ResponseWriter, r *http.Request, flowState oidcFlowState) error {
+	payload, err := json.Marshal(flowState)
+	if err != nil {
+		return err
+	}
+
+	if len(payload) > OIDC_STATE_MAX_DATA_SIZE {
+		return fmt.Errorf("oidc state payload is too large")
+	}
+
+	expires := time.Now().Add(OIDC_STATE_VALID_PERIOD)
+	data := make([]byte, AUTH_TIMESTAMP_LENGTH+len(payload))
+	binary.LittleEndian.PutUint32(data[0:AUTH_TIMESTAMP_LENGTH], uint32(expires.Unix()))
+	copy(data[AUTH_TIMESTAMP_LENGTH:], payload)
+
+	h := hmac.New(sha256.New, a.authSecretKey[0:AUTH_TOKEN_SECRET_LENGTH])
+	h.Write(data)
+	signed := base64.StdEncoding.EncodeToString(append(data, h.Sum(nil)...))
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     OIDC_STATE_COOKIE_NAME,
+		Value:    signed,
+		Expires:  expires,
+		Secure:   strings.ToLower(r.Header.Get("X-Forwarded-Proto")) == "https",
+		Path:     a.Config.Server.BaseURL + "/",
+		SameSite: http.SameSiteLaxMode,
+		HttpOnly: true,
+	})
+
+	return nil
+}
+
+func (a *application) readOIDCStateCookie(r *http.Request) (oidcFlowState, error) {
+	var flowState oidcFlowState
+
+	cookie, err := r.Cookie(OIDC_STATE_COOKIE_NAME)
+	if err != nil || cookie.Value == "" {
+		return flowState, fmt.Errorf("oidc state cookie is missing")
+	}
+
+	tokenBytes, err := base64.StdEncoding.DecodeString(cookie.Value)
+	if err != nil {
+		return flowState, err
+	}
+
+	if len(tokenBytes) < AUTH_TIMESTAMP_LENGTH+32 {
+		return flowState, fmt.Errorf("oidc state cookie is too short")
+	}
+
+	dataEnd := len(tokenBytes) - 32
+	data := tokenBytes[0:dataEnd]
+	providedSignature := tokenBytes[dataEnd:]
+
+	h := hmac.New(sha256.New, a.authSecretKey[0:AUTH_TOKEN_SECRET_LENGTH])
+	h.Write(data)
+	if !hmac.Equal(h.Sum(nil), providedSignature) {
+		return flowState, fmt.Errorf("oidc state cookie signature is invalid")
+	}
+
+	expires := int64(binary.LittleEndian.Uint32(data[0:AUTH_TIMESTAMP_LENGTH]))
+	if time.Now().Unix() > expires {
+		return flowState, fmt.Errorf("oidc state cookie has expired")
+	}
+
+	payload := data[AUTH_TIMESTAMP_LENGTH:]
+	if len(payload) > OIDC_STATE_MAX_DATA_SIZE {
+		return flowState, fmt.Errorf("oidc state payload is too large")
+	}
+
+	if err := json.Unmarshal(payload, &flowState); err != nil {
+		return flowState, err
+	}
+
+	if flowState.State == "" || flowState.Nonce == "" || flowState.CodeVerifier == "" || flowState.RedirectURL == "" {
+		return flowState, fmt.Errorf("oidc state cookie is incomplete")
+	}
+
+	return flowState, nil
+}
+
+func (a *application) clearOIDCStateCookie(w http.ResponseWriter, r *http.Request) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     OIDC_STATE_COOKIE_NAME,
+		Value:    "",
+		Expires:  time.Now().Add(-1 * time.Hour),
+		Secure:   strings.ToLower(r.Header.Get("X-Forwarded-Proto")) == "https",
+		Path:     a.Config.Server.BaseURL + "/",
+		SameSite: http.SameSiteLaxMode,
+		HttpOnly: true,
+	})
+}

--- a/internal/glance/auth_oidc.go
+++ b/internal/glance/auth_oidc.go
@@ -24,10 +24,7 @@ const (
 	oidcLoginErrorParam      = "oidc"
 )
 
-var (
-	defaultOIDCScopes         = []string{oidc.ScopeOpenID, "profile", "email"}
-	defaultOIDCUsernameClaims = []string{"preferred_username", "email", "sub"}
-)
+var oidcScopes = []string{oidc.ScopeOpenID}
 
 type oidcFlowState struct {
 	State        string `json:"state"`
@@ -50,17 +47,12 @@ func (a *application) initOIDCAuth() error {
 		return fmt.Errorf("initializing oidc provider: %w", err)
 	}
 
-	scopes := oidcConfig.Scopes
-	if len(scopes) == 0 {
-		scopes = defaultOIDCScopes
-	}
-
 	a.oidcVerifier = provider.Verifier(&oidc.Config{ClientID: oidcConfig.ClientID})
 	a.oauth2Config = &oauth2.Config{
 		ClientID:     oidcConfig.ClientID,
 		ClientSecret: oidcConfig.ClientSecret,
 		Endpoint:     provider.Endpoint(),
-		Scopes:       scopes,
+		Scopes:       oidcScopes,
 	}
 	a.oidcEnabled = true
 
@@ -204,9 +196,9 @@ func (a *application) handleOIDCCallback(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	username, err := usernameFromOIDCToken(idToken, a.Config.Auth.OIDC.UsernameClaim)
-	if err != nil {
-		a.failOIDCCallback(w, r, "Could not resolve oidc username from %s: %v", ip, err)
+	username := idToken.Subject
+	if username == "" {
+		a.failOIDCCallback(w, r, "Missing sub claim in oidc id token from %s", ip)
 		return
 	}
 
@@ -248,47 +240,6 @@ func (a *application) registerOIDCUser(username string) error {
 
 	a.usernameHashToUsername[hashKey] = username
 	return nil
-}
-
-func usernameFromOIDCToken(idToken *oidc.IDToken, usernameClaim string) (string, error) {
-	var claims map[string]any
-	if err := idToken.Claims(&claims); err != nil {
-		return "", err
-	}
-
-	return usernameFromClaims(claims, usernameClaim)
-}
-
-func usernameFromClaims(claims map[string]any, usernameClaim string) (string, error) {
-	if usernameClaim != "" {
-		username, ok := stringClaim(claims, usernameClaim)
-		if !ok {
-			return "", fmt.Errorf("username claim %q is missing or empty", usernameClaim)
-		}
-		return username, nil
-	}
-
-	for _, claim := range defaultOIDCUsernameClaims {
-		if username, ok := stringClaim(claims, claim); ok {
-			return username, nil
-		}
-	}
-
-	return "", fmt.Errorf("no usable username claim found in id token")
-}
-
-func stringClaim(claims map[string]any, name string) (string, bool) {
-	value, ok := claims[name]
-	if !ok {
-		return "", false
-	}
-
-	claim, ok := value.(string)
-	if !ok || claim == "" {
-		return "", false
-	}
-
-	return claim, true
 }
 
 func (a *application) failOIDCCallback(w http.ResponseWriter, r *http.Request, format string, args ...any) {

--- a/internal/glance/auth_oidc_test.go
+++ b/internal/glance/auth_oidc_test.go
@@ -67,64 +67,6 @@ func TestOIDCStateCookieRoundTrip(t *testing.T) {
 	}
 }
 
-func TestUsernameFromOIDCClaims(t *testing.T) {
-	tests := []struct {
-		name          string
-		claims        map[string]any
-		usernameClaim string
-		want          string
-		wantErr       bool
-	}{
-		{
-			name:          "explicit claim",
-			claims:        map[string]any{"preferred_username": "alice"},
-			usernameClaim: "preferred_username",
-			want:          "alice",
-		},
-		{
-			name:    "fallback to email",
-			claims:  map[string]any{"email": "alice@example.com"},
-			want:    "alice@example.com",
-		},
-		{
-			name:    "fallback to sub",
-			claims:  map[string]any{"sub": "provider-user-id"},
-			want:    "provider-user-id",
-		},
-		{
-			name:          "missing explicit claim",
-			claims:        map[string]any{"email": "alice@example.com"},
-			usernameClaim: "preferred_username",
-			wantErr:       true,
-		},
-		{
-			name:    "no usable claims",
-			claims:  map[string]any{},
-			wantErr: true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			username, err := usernameFromClaims(test.claims, test.usernameClaim)
-			if test.wantErr {
-				if err == nil {
-					t.Fatal("Expected error, got nil")
-				}
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-
-			if username != test.want {
-				t.Fatalf("Expected username %q, got %q", test.want, username)
-			}
-		})
-	}
-}
-
 func TestRegisterOIDCUserAllowsAuthorization(t *testing.T) {
 	secret, err := makeAuthSecretKey(AUTH_SECRET_KEY_LENGTH)
 	if err != nil {

--- a/internal/glance/auth_oidc_test.go
+++ b/internal/glance/auth_oidc_test.go
@@ -106,7 +106,7 @@ func TestUsernameFromOIDCClaims(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			username, err := usernameFromClaimsMap(test.claims, test.usernameClaim)
+			username, err := usernameFromClaims(test.claims, test.usernameClaim)
 			if test.wantErr {
 				if err == nil {
 					t.Fatal("Expected error, got nil")
@@ -140,7 +140,6 @@ func TestRegisterOIDCUserAllowsAuthorization(t *testing.T) {
 		RequiresAuth:           true,
 		authSecretKey:          secretBytes,
 		usernameHashToUsername: make(map[string]string),
-		oidcUsernames:          make(map[string]struct{}),
 		oidcEnabled:            true,
 		Config: config{
 			Auth: struct {
@@ -171,32 +170,6 @@ func TestRegisterOIDCUserAllowsAuthorization(t *testing.T) {
 	}
 }
 
-func usernameFromClaimsMap(claims map[string]any, usernameClaim string) (string, error) {
-	if usernameClaim != "" {
-		username, ok := stringClaim(claims, usernameClaim)
-		if !ok {
-			return "", errMissingClaim
-		}
-		return username, nil
-	}
-
-	for _, claim := range []string{"preferred_username", "email", "sub"} {
-		if username, ok := stringClaim(claims, claim); ok {
-			return username, nil
-		}
-	}
-
-	return "", errMissingClaim
-}
-
-var errMissingClaim = errTestMissingClaim{}
-
-type errTestMissingClaim struct{}
-
-func (errTestMissingClaim) Error() string {
-	return "missing claim"
-}
-
 func TestOIDCRedirectURLUsesRequestHost(t *testing.T) {
 	app := &application{
 		Config: config{
@@ -220,5 +193,31 @@ func TestOIDCRedirectURLUsesRequestHost(t *testing.T) {
 	want := "https://example.com/glance/auth/oidc/callback"
 	if got != want {
 		t.Fatalf("Expected %q, got %q", want, got)
+	}
+}
+
+func TestBeginAuthAttemptRateLimit(t *testing.T) {
+	app := &application{
+		failedAuthAttempts: make(map[string]*failedAuthAttempt),
+	}
+
+	ip := "127.0.0.1"
+	for i := 0; i < AUTH_RATE_LIMIT_MAX_ATTEMPTS; i++ {
+		app.authAttemptsMu.Lock()
+		exceeded, _ := app.beginAuthAttempt(ip)
+		app.authAttemptsMu.Unlock()
+		if exceeded {
+			t.Fatalf("Expected attempt %d not to be rate limited", i+1)
+		}
+	}
+
+	app.authAttemptsMu.Lock()
+	exceeded, retryAfter := app.beginAuthAttempt(ip)
+	app.authAttemptsMu.Unlock()
+	if !exceeded {
+		t.Fatal("Expected rate limit to be exceeded")
+	}
+	if retryAfter <= 0 {
+		t.Fatalf("Expected positive retry-after, got %d", retryAfter)
 	}
 }

--- a/internal/glance/auth_oidc_test.go
+++ b/internal/glance/auth_oidc_test.go
@@ -1,0 +1,224 @@
+package glance
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestOIDCStateCookieRoundTrip(t *testing.T) {
+	secret, err := makeAuthSecretKey(AUTH_SECRET_KEY_LENGTH)
+	if err != nil {
+		t.Fatalf("Failed to generate secret key: %v", err)
+	}
+
+	secretBytes, err := base64.StdEncoding.DecodeString(secret)
+	if err != nil {
+		t.Fatalf("Failed to decode secret key: %v", err)
+	}
+
+	app := &application{
+		authSecretKey: secretBytes,
+		Config: config{
+			Server: struct {
+				Host       string `yaml:"host"`
+				Port       uint16 `yaml:"port"`
+				Proxied    bool   `yaml:"proxied"`
+				AssetsPath string `yaml:"assets-path"`
+				BaseURL    string `yaml:"base-url"`
+			}{
+				BaseURL: "",
+			},
+		},
+	}
+
+	flowState := oidcFlowState{
+		State:        "state-value",
+		Nonce:        "nonce-value",
+		CodeVerifier: "verifier-value",
+		RedirectURL:  "https://glance.example.com/auth/oidc/callback",
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("X-Forwarded-Proto", "https")
+	recorder := httptest.NewRecorder()
+
+	if err := app.setOIDCStateCookie(recorder, request, flowState); err != nil {
+		t.Fatalf("Failed to set oidc state cookie: %v", err)
+	}
+
+	response := recorder.Result()
+	if len(response.Cookies()) != 1 {
+		t.Fatalf("Expected 1 cookie, got %d", len(response.Cookies()))
+	}
+
+	callbackRequest := httptest.NewRequest(http.MethodGet, "/", nil)
+	callbackRequest.AddCookie(response.Cookies()[0])
+
+	readState, err := app.readOIDCStateCookie(callbackRequest)
+	if err != nil {
+		t.Fatalf("Failed to read oidc state cookie: %v", err)
+	}
+
+	if readState != flowState {
+		t.Fatalf("Expected %+v, got %+v", flowState, readState)
+	}
+}
+
+func TestUsernameFromOIDCClaims(t *testing.T) {
+	tests := []struct {
+		name          string
+		claims        map[string]any
+		usernameClaim string
+		want          string
+		wantErr       bool
+	}{
+		{
+			name:          "explicit claim",
+			claims:        map[string]any{"preferred_username": "alice"},
+			usernameClaim: "preferred_username",
+			want:          "alice",
+		},
+		{
+			name:    "fallback to email",
+			claims:  map[string]any{"email": "alice@example.com"},
+			want:    "alice@example.com",
+		},
+		{
+			name:    "fallback to sub",
+			claims:  map[string]any{"sub": "provider-user-id"},
+			want:    "provider-user-id",
+		},
+		{
+			name:          "missing explicit claim",
+			claims:        map[string]any{"email": "alice@example.com"},
+			usernameClaim: "preferred_username",
+			wantErr:       true,
+		},
+		{
+			name:    "no usable claims",
+			claims:  map[string]any{},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			username, err := usernameFromClaimsMap(test.claims, test.usernameClaim)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("Expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if username != test.want {
+				t.Fatalf("Expected username %q, got %q", test.want, username)
+			}
+		})
+	}
+}
+
+func TestRegisterOIDCUserAllowsAuthorization(t *testing.T) {
+	secret, err := makeAuthSecretKey(AUTH_SECRET_KEY_LENGTH)
+	if err != nil {
+		t.Fatalf("Failed to generate secret key: %v", err)
+	}
+
+	secretBytes, err := base64.StdEncoding.DecodeString(secret)
+	if err != nil {
+		t.Fatalf("Failed to decode secret key: %v", err)
+	}
+
+	app := &application{
+		RequiresAuth:           true,
+		authSecretKey:          secretBytes,
+		usernameHashToUsername: make(map[string]string),
+		oidcUsernames:          make(map[string]struct{}),
+		oidcEnabled:            true,
+		Config: config{
+			Auth: struct {
+				SecretKey string           `yaml:"secret-key"`
+				Users     map[string]*user `yaml:"users"`
+				OIDC      oidcConfig       `yaml:"oidc"`
+			}{
+				Users: map[string]*user{},
+			},
+		},
+	}
+
+	if err := app.registerOIDCUser("oidc-user"); err != nil {
+		t.Fatalf("Failed to register oidc user: %v", err)
+	}
+
+	token, err := generateSessionToken("oidc-user", secretBytes, time.Now())
+	if err != nil {
+		t.Fatalf("Failed to generate session token: %v", err)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(&http.Cookie{Name: AUTH_SESSION_COOKIE_NAME, Value: token})
+	recorder := httptest.NewRecorder()
+
+	if !app.isAuthorized(recorder, request) {
+		t.Fatal("Expected oidc user to be authorized")
+	}
+}
+
+func usernameFromClaimsMap(claims map[string]any, usernameClaim string) (string, error) {
+	if usernameClaim != "" {
+		username, ok := stringClaim(claims, usernameClaim)
+		if !ok {
+			return "", errMissingClaim
+		}
+		return username, nil
+	}
+
+	for _, claim := range []string{"preferred_username", "email", "sub"} {
+		if username, ok := stringClaim(claims, claim); ok {
+			return username, nil
+		}
+	}
+
+	return "", errMissingClaim
+}
+
+var errMissingClaim = errTestMissingClaim{}
+
+type errTestMissingClaim struct{}
+
+func (errTestMissingClaim) Error() string {
+	return "missing claim"
+}
+
+func TestOIDCRedirectURLUsesRequestHost(t *testing.T) {
+	app := &application{
+		Config: config{
+			Server: struct {
+				Host       string `yaml:"host"`
+				Port       uint16 `yaml:"port"`
+				Proxied    bool   `yaml:"proxied"`
+				AssetsPath string `yaml:"assets-path"`
+				BaseURL    string `yaml:"base-url"`
+			}{
+				BaseURL: "/glance",
+			},
+		},
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "http://example.com/glance/login", nil)
+	request.Header.Set("X-Forwarded-Proto", "https")
+	request.Host = "example.com"
+
+	got := app.oidcRedirectURL(request)
+	want := "https://example.com/glance/auth/oidc/callback"
+	if got != want {
+		t.Fatalf("Expected %q, got %q", want, got)
+	}
+}

--- a/internal/glance/config.go
+++ b/internal/glance/config.go
@@ -39,6 +39,7 @@ type config struct {
 	Auth struct {
 		SecretKey string           `yaml:"secret-key"`
 		Users     map[string]*user `yaml:"users"`
+		OIDC      oidcConfig       `yaml:"oidc"`
 	} `yaml:"auth"`
 
 	Document struct {
@@ -72,6 +73,21 @@ type user struct {
 	Password           string `yaml:"password"`
 	PasswordHashString string `yaml:"password-hash"`
 	PasswordHash       []byte `yaml:"-"`
+}
+
+type oidcConfig struct {
+	Issuer            string   `yaml:"issuer"`
+	ClientID          string   `yaml:"client-id"`
+	ClientSecret      string   `yaml:"client-secret"`
+	RedirectURL       string   `yaml:"redirect-url"`
+	Scopes            []string `yaml:"scopes"`
+	UsernameClaim     string   `yaml:"username-claim"`
+	AutoLogin         bool     `yaml:"auto-login"`
+	DisableLocalLogin bool     `yaml:"disable-local-login"`
+}
+
+func authConfigured(config *config) bool {
+	return len(config.Auth.Users) > 0 || config.Auth.OIDC.Issuer != ""
 }
 
 type page struct {
@@ -453,8 +469,18 @@ func isConfigStateValid(config *config) error {
 		return fmt.Errorf("no pages configured")
 	}
 
-	if len(config.Auth.Users) > 0 && config.Auth.SecretKey == "" {
-		return fmt.Errorf("secret-key must be set when users are configured")
+	if authConfigured(config) && config.Auth.SecretKey == "" {
+		return fmt.Errorf("secret-key must be set when authentication is configured")
+	}
+
+	if config.Auth.OIDC.Issuer != "" {
+		if config.Auth.OIDC.ClientID == "" {
+			return fmt.Errorf("oidc client-id must be set when oidc issuer is configured")
+		}
+
+		if config.Auth.OIDC.ClientSecret == "" {
+			return fmt.Errorf("oidc client-secret must be set when oidc issuer is configured")
+		}
 	}
 
 	for username := range config.Auth.Users {

--- a/internal/glance/config.go
+++ b/internal/glance/config.go
@@ -76,14 +76,12 @@ type user struct {
 }
 
 type oidcConfig struct {
-	Issuer            string   `yaml:"issuer"`
-	ClientID          string   `yaml:"client-id"`
-	ClientSecret      string   `yaml:"client-secret"`
-	RedirectURL       string   `yaml:"redirect-url"`
-	Scopes            []string `yaml:"scopes"`
-	UsernameClaim     string   `yaml:"username-claim"`
-	AutoLogin         bool     `yaml:"auto-login"`
-	DisableLocalLogin bool     `yaml:"disable-local-login"`
+	Issuer            string `yaml:"issuer"`
+	ClientID          string `yaml:"client-id"`
+	ClientSecret      string `yaml:"client-secret"`
+	RedirectURL       string `yaml:"redirect-url"`
+	AutoLogin         bool   `yaml:"auto-login"`
+	DisableLocalLogin bool   `yaml:"disable-local-login"`
 }
 
 func authConfigured(config *config) bool {

--- a/internal/glance/glance.go
+++ b/internal/glance/glance.go
@@ -42,14 +42,13 @@ type application struct {
 	RequiresAuth           bool
 	authSecretKey          []byte
 	usernameHashToUsername map[string]string
+	usernameHashMu         sync.RWMutex
 	authAttemptsMu         sync.Mutex
 	failedAuthAttempts     map[string]*failedAuthAttempt
 
-	oidcEnabled      bool
-	oidcVerifier     *oidc.IDTokenVerifier
-	oauth2Config     *oauth2.Config
-	oidcUsernames    map[string]struct{}
-	oidcUsernamesMu  sync.RWMutex
+	oidcEnabled  bool
+	oidcVerifier *oidc.IDTokenVerifier
+	oauth2Config *oauth2.Config
 }
 
 func newApplication(c *config) (*application, error) {

--- a/internal/glance/glance.go
+++ b/internal/glance/glance.go
@@ -14,7 +14,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/oauth2"
 )
 
 var (
@@ -25,7 +27,7 @@ var (
 
 const STATIC_ASSETS_CACHE_DURATION = 24 * time.Hour
 
-var reservedPageSlugs = []string{"login", "logout"}
+var reservedPageSlugs = []string{"login", "logout", "auth"}
 
 type application struct {
 	Version   string
@@ -42,6 +44,12 @@ type application struct {
 	usernameHashToUsername map[string]string
 	authAttemptsMu         sync.Mutex
 	failedAuthAttempts     map[string]*failedAuthAttempt
+
+	oidcEnabled      bool
+	oidcVerifier     *oidc.IDTokenVerifier
+	oauth2Config     *oauth2.Config
+	oidcUsernames    map[string]struct{}
+	oidcUsernamesMu  sync.RWMutex
 }
 
 func newApplication(c *config) (*application, error) {
@@ -58,7 +66,7 @@ func newApplication(c *config) (*application, error) {
 	// Init auth
 	//
 
-	if len(config.Auth.Users) > 0 {
+	if authConfigured(config) {
 		secretBytes, err := base64.StdEncoding.DecodeString(config.Auth.SecretKey)
 		if err != nil {
 			return nil, fmt.Errorf("decoding secret-key: %v", err)
@@ -71,6 +79,7 @@ func newApplication(c *config) (*application, error) {
 		app.usernameHashToUsername = make(map[string]string)
 		app.failedAuthAttempts = make(map[string]*failedAuthAttempt)
 		app.RequiresAuth = true
+		app.authSecretKey = secretBytes
 
 		for username := range config.Auth.Users {
 			user := config.Auth.Users[username]
@@ -94,7 +103,9 @@ func newApplication(c *config) (*application, error) {
 			}
 		}
 
-		app.authSecretKey = secretBytes
+		if err := app.initOIDCAuth(); err != nil {
+			return nil, err
+		}
 	}
 
 	//
@@ -282,9 +293,11 @@ type templateRequestData struct {
 }
 
 type templateData struct {
-	App     *application
-	Page    *page
-	Request templateRequestData
+	App             *application
+	Page            *page
+	Request         templateRequestData
+	ShowLocalLogin  bool
+	ShowOIDCLogin   bool
 }
 
 func (a *application) populateTemplateRequestData(data *templateRequestData, r *http.Request) {
@@ -453,7 +466,15 @@ func (a *application) server() (func() error, func() error) {
 	if a.RequiresAuth {
 		mux.HandleFunc("GET /login", a.handleLoginPageRequest)
 		mux.HandleFunc("GET /logout", a.handleLogoutRequest)
-		mux.HandleFunc("POST /api/authenticate", a.handleAuthenticationAttempt)
+
+		if a.LocalAuthEnabled() {
+			mux.HandleFunc("POST /api/authenticate", a.handleAuthenticationAttempt)
+		}
+
+		if a.oidcEnabled {
+			mux.HandleFunc("GET /auth/oidc/login", a.handleOIDCLogin)
+			mux.HandleFunc("GET /auth/oidc/callback", a.handleOIDCCallback)
+		}
 	}
 
 	mux.Handle(

--- a/internal/glance/login_template_test.go
+++ b/internal/glance/login_template_test.go
@@ -1,0 +1,114 @@
+package glance
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func loginTemplateData(app *application) *templateData {
+	return &templateData{
+		App:            app,
+		ShowLocalLogin: app.showLocalLoginForm(),
+		ShowOIDCLogin:  app.oidcEnabled,
+		Request: templateRequestData{
+			Theme: &app.Config.Theme.themeProperties,
+		},
+	}
+}
+
+func TestLoginTemplateLocalAndOIDC(t *testing.T) {
+	app := &application{
+		RequiresAuth: true,
+		oidcEnabled:  true,
+		Config: config{
+			Auth: struct {
+				SecretKey string           `yaml:"secret-key"`
+				Users     map[string]*user `yaml:"users"`
+				OIDC      oidcConfig       `yaml:"oidc"`
+			}{
+				Users: map[string]*user{"admin": {PasswordHash: []byte("x")}},
+				OIDC: oidcConfig{
+					Issuer:            "https://example.com",
+					DisableLocalLogin: false,
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := loginPageTemplate.Execute(&buf, loginTemplateData(app)); err != nil {
+		t.Fatal(err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, `id="username"`) {
+		t.Fatalf("expected username field, got:\n%s", out)
+	}
+	if !strings.Contains(out, "SIGN IN WITH SSO") {
+		t.Fatal("expected SSO button")
+	}
+}
+
+func TestLoginTemplateOIDCOnly(t *testing.T) {
+	app := &application{
+		RequiresAuth: true,
+		oidcEnabled:  true,
+		Config: config{
+			Auth: struct {
+				SecretKey string           `yaml:"secret-key"`
+				Users     map[string]*user `yaml:"users"`
+				OIDC      oidcConfig       `yaml:"oidc"`
+			}{
+				Users: map[string]*user{},
+				OIDC: oidcConfig{
+					Issuer:            "https://example.com",
+					DisableLocalLogin: false,
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := loginPageTemplate.Execute(&buf, loginTemplateData(app)); err != nil {
+		t.Fatal(err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, `id="username"`) {
+		t.Fatalf("should not show username without local users")
+	}
+	if !strings.Contains(out, "SIGN IN WITH SSO") {
+		t.Fatal("expected SSO button")
+	}
+}
+
+func TestLoginTemplateDisableLocalLogin(t *testing.T) {
+	app := &application{
+		RequiresAuth: true,
+		oidcEnabled:  true,
+		Config: config{
+			Auth: struct {
+				SecretKey string           `yaml:"secret-key"`
+				Users     map[string]*user `yaml:"users"`
+				OIDC      oidcConfig       `yaml:"oidc"`
+			}{
+				Users: map[string]*user{"admin": {PasswordHash: []byte("x")}},
+				OIDC: oidcConfig{
+					Issuer:            "https://example.com",
+					DisableLocalLogin: true,
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := loginPageTemplate.Execute(&buf, loginTemplateData(app)); err != nil {
+		t.Fatal(err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, `id="username"`) {
+		t.Fatalf("should not show username when disable-local-login is true")
+	}
+}

--- a/internal/glance/static/css/login.css
+++ b/internal/glance/static/css/login.css
@@ -97,6 +97,28 @@
     transform: translateX(.5rem);
 }
 
+.login-button-sso {
+    text-decoration: none;
+}
+
+.login-divider {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin: 2.5rem 0 2rem;
+    color: var(--color-text-subdue);
+    text-transform: uppercase;
+    font-size: var(--font-size-small);
+}
+
+.login-divider::before,
+.login-divider::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--color-separator);
+}
+
 .animate-entrance {
     animation: fieldReveal 0.7s backwards;
     animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);

--- a/internal/glance/static/js/login.js
+++ b/internal/glance/static/js/login.js
@@ -31,26 +31,39 @@ const lang = {
     incorrectCredentials: "Incorrect username or password",
     rateLimited: "Too many login attempts, try again in a few minutes",
     unknownError: "An error occurred, please try again",
+    oidcError: "Single sign-on failed, please try again",
 };
 
-container.clearStyles("display");
-setTimeout(() => usernameInput.focus(), 200);
+const urlParams = new URLSearchParams(window.location.search);
+if (errorMessage && urlParams.get("error") === "oidc") {
+    errorMessage.text(lang.oidcError);
+}
 
-toggleVisibilityButton
-    .html(showPasswordSVG)
-    .attr("title", lang.showPassword)
-    .on("click", function() {
-        if (passwordInput.type === "password") {
-            passwordInput.type = "text";
-            toggleVisibilityButton.html(hidePasswordSVG).attr("title", lang.hidePassword);
-            return;
-        }
+if (usernameInput) {
+    setTimeout(() => usernameInput.focus(), 200);
+}
 
-        passwordInput.type = "password";
-        toggleVisibilityButton.html(showPasswordSVG).attr("title", lang.showPassword);
-    });
+if (toggleVisibilityButton && passwordInput) {
+    toggleVisibilityButton
+        .html(showPasswordSVG)
+        .attr("title", lang.showPassword)
+        .on("click", function() {
+            if (passwordInput.type === "password") {
+                passwordInput.type = "text";
+                toggleVisibilityButton.html(hidePasswordSVG).attr("title", lang.hidePassword);
+                return;
+            }
+
+            passwordInput.type = "password";
+            toggleVisibilityButton.html(showPasswordSVG).attr("title", lang.showPassword);
+        });
+}
 
 function enableLoginButtonIfCriteriaMet() {
+    if (!usernameInput || !passwordInput || !loginButton) {
+        return;
+    }
+
     const usernameValue = usernameInput.value.trim();
     const passwordValue = passwordInput.value.trim();
 
@@ -72,21 +85,27 @@ function enableLoginButtonIfCriteriaMet() {
 
 function handleLoginWithEnter(event) {
     if (event.key !== "Enter") return;
-    if (loginButton.disabled) return;
+    if (!loginButton || loginButton.disabled) return;
 
     document.activeElement.blur();
     handleLoginAttempt();
 }
 
-usernameInput
-    .on("input", enableLoginButtonIfCriteriaMet)
-    .on("keydown", handleLoginWithEnter);
+if (usernameInput && passwordInput) {
+    usernameInput
+        .on("input", enableLoginButtonIfCriteriaMet)
+        .on("keydown", handleLoginWithEnter);
 
-passwordInput
-    .on("input", enableLoginButtonIfCriteriaMet)
-    .on("keydown", handleLoginWithEnter);
+    passwordInput
+        .on("input", enableLoginButtonIfCriteriaMet)
+        .on("keydown", handleLoginWithEnter);
+}
 
 async function handleLoginAttempt() {
+    if (!usernameInput || !passwordInput || !loginButton || !errorMessage) {
+        return;
+    }
+
     state.lastUsername = usernameInput.value;
     state.lastPassword = passwordInput.value;
     errorMessage.text("");
@@ -109,7 +128,7 @@ async function handleLoginAttempt() {
     if (response.status === 200) {
         setTimeout(() => { window.location.href = pageData.baseURL + "/"; }, 300);
 
-        container.animate({
+        container?.animate({
             keyframes: [{ offset: 1, transform: "scale(0.95)", opacity: 0 }],
             options: { duration: 300, easing: "ease", fill: "forwards" }}
         );
@@ -138,4 +157,6 @@ async function handleLoginAttempt() {
     }
 }
 
-loginButton.disable().on("click", handleLoginAttempt);
+if (loginButton) {
+    loginButton.disable().on("click", handleLoginAttempt);
+}

--- a/internal/glance/templates/login.html
+++ b/internal/glance/templates/login.html
@@ -16,7 +16,21 @@
 <div class="flex flex-column body-content">
     <div class="flex grow items-center justify-center" style="padding-bottom: 5rem">
         <h1 class="visually-hidden">Login</h1>
-        <main id="login-container" class="grow login-bounds" style="display: none;">
+        <main id="login-container" class="grow login-bounds">
+            {{ if .ShowOIDCLogin }}
+            <a class="login-button login-button-sso animate-entrance" href="{{ .App.Config.Server.BaseURL }}/auth/oidc/login">
+                <div>SIGN IN WITH SSO</div>
+                <svg stroke="currentColor" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
+                </svg>
+            </a>
+            {{ end }}
+
+            {{ if .ShowLocalLogin }}
+            {{ if .ShowOIDCLogin }}
+            <div class="login-divider animate-entrance">or</div>
+            {{ end }}
+
             <div class="animate-entrance">
                 <label class="form-label widget-header" for="username">Username</label>
                 <div class="form-input widget-content-frame padding-inline-widget flex gap-10 items-center">
@@ -38,14 +52,15 @@
                 </div>
             </div>
 
-            <div class="login-error-message" id="error-message"></div>
-
             <button class="login-button animate-entrance" id="login-button">
                 <div>LOGIN</div>
                 <svg stroke="currentColor" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
                 </svg>
             </button>
+            {{ end }}
+
+            <div class="login-error-message" id="error-message"></div>
         </main>
     </div>
     {{ template "footer.html" . }}


### PR DESCRIPTION
Adds optional OpenID Connect (OIDC) authentication to Glance alongside the existing local username/password flow. My problem with the current username/password flow is that on one of my notebooks I cant have a good password manager installed/used. Using a OIDC provider solves pretty much all my hassle and glance still has the same functionality for one dashboard.

Users can sign in via any standard OIDC provider (Keycloak, PocketID, Authelia, Google, etc.) using a "Sign in with SSO" button on the login page. After IdP authentication, Glance issues the same HMAC session cookie used by local login.
The feature can be used alone or together with local users. I limited the scope to OpenID only, as that's all that is really needed.

As I am currently time-constrained, the PR is authored with the help of Cursor and [CE-Skills](https://github.com/EveryInc/compound-engineering-plugin). Keep that in mind. If it is not the direction glance should/will be heading, it's ok to close the PR.

### Configuration
```
auth:
  secret-key: ...
  oidc:
    issuer: https://auth.example.com/realms/home
    client-id: glance
    client-secret: ...
```
Register redirect URI: {base-url}/auth/oidc/callback
Optional flags: auto-login, disable-local-login, redirect-url

### Implementation notes
Authorization code flow with PKCE, signed state cookie, nonce validation, and ID token verification via go-oidc
Shared rate limiting and cookie helpers with existing local auth
Config hot-reload re-inits the OIDC provider like other auth settings
Login UI supports SSO-only, local-only, or both

### Test plan

- [ ]  OIDC-only login against a test IdP (Keycloak / PocketID / etc.)
- [ ]  Redirect URI works with and without server.base-url
- [ ]  Works behind reverse proxy with server.proxied: true
- [ ]  Local + OIDC login both work when users and oidc are configured
- [ ]  disable-local-login: true hides username/password form
- [ ]  Failed OIDC callback shows error on login page (?error=oidc)
- [ ]  Logout clears session cookie
- [ ]  go test ./... passes

One line worth calling out for reviewers: OIDC user sessions are tied to in-memory sub → hash mappings, so they don't survive a config reload until the user signs in again (same pattern as removing a local user from config).