### PR TITLE
fix: use last IP from X-Forwarded-For to prevent rate limit bypass

### DIFF
--- a/internal/glance/address_test.go
+++ b/internal/glance/address_test.go
@@ -1,0 +1,43 @@
+package glance
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestAddressOfRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		proxied    bool
+		remoteAddr string
+		xff        string
+		want       string
+	}{
+		{"not proxied - uses remote addr", false, "1.2.3.4:5678", "", "1.2.3.4"},
+		{"proxied - no XFF header", true, "1.2.3.4:5678", "", "1.2.3.4"},
+		{"proxied - single IP", true, "1.2.3.4:5678", "5.6.7.8", "5.6.7.8"},
+		{"proxied - multiple IPs returns last", true, "1.2.3.4:5678", "1.2.3.4, 5.6.7.8", "5.6.7.8"},
+		{"proxied - spoofed first IP ignored", true, "1.2.3.4:5678", "99.99.99.99, 1.2.3.4", "1.2.3.4"},
+		{"proxied - empty XFF", true, "1.2.3.4:5678", "", "1.2.3.4"},
+		{"proxied - trailing comma falls back", true, "1.2.3.4:5678", "5.6.7.8,", "1.2.3.4"},
+		{"proxied - whitespace trimmed", true, "1.2.3.4:5678", "  5.6.7.8  ", "5.6.7.8"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := &application{Config: config{}}
+			app.Config.Server.Proxied = tt.proxied
+
+			req := &http.Request{RemoteAddr: tt.remoteAddr}
+			if tt.xff != "" {
+				req.Header = http.Header{}
+				req.Header.Set("X-Forwarded-For", tt.xff)
+			}
+
+			got := app.addressOfRequest(req)
+			if got != tt.want {
+				t.Errorf("addressOfRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/glance/glance.go
+++ b/internal/glance/glance.go
@@ -388,11 +388,20 @@ func (a *application) addressOfRequest(r *http.Request) string {
 	}
 
 	ips := strings.Split(forwardedFor, ",")
-	if len(ips) == 0 || ips[0] == "" {
+	if len(ips) == 0 {
 		return remoteAddrWithoutPort()
 	}
 
-	return ips[0]
+	// Use the last (rightmost) IP in X-Forwarded-For, as this is the
+	// one added by the trusted reverse proxy. The leftmost values can
+	// be spoofed by the client and must not be trusted for rate limiting
+	// or other security-sensitive operations.
+	lastIP := strings.TrimSpace(ips[len(ips)-1])
+	if lastIP == "" {
+		return remoteAddrWithoutPort()
+	}
+
+	return lastIP
 }
 
 func (a *application) handleNotFound(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## Summary

When the server is configured with `proxied: true`, `addressOfRequest()` was returning the first (leftmost) IP from the `X-Forwarded-For` header. This value is client-controlled and can be spoofed, allowing attackers to bypass the login rate limit by rotating the spoofed IP on each request.

The fix changes the function to use the **last (rightmost) IP** instead, which is the one appended by the trusted reverse proxy (e.g., nginx with `$proxy_add_x_forwarded_for`). This ensures the rate limiter always sees the real client IP address.

## Changes

- **`internal/glance/glance.go`**: Modified `addressOfRequest()` to return the last IP in `X-Forwarded-For` with `strings.TrimSpace()` to handle whitespace
- **`internal/glance/address_test.go`** (new): 8 test cases covering:
  - Non-proxied mode (uses RemoteAddr)
  - Proxied mode with no XFF header (falls back to RemoteAddr)
  - Single IP in XFF
  - Multiple IPs in XFF (returns last)
  - Spoofed first IP (ignored, returns real IP from the end)
  - Empty XFF (falls back to RemoteAddr)
  - Trailing comma (falls back to RemoteAddr)
  - Whitespace trimming

## Testing

- All 9 tests pass (8 new + 1 existing `TestAuthTokenGenerationAndVerification`)
- `go test ./internal/glance/ -v` passes

Fixes #1031