### PR TITLE
Document syntax of sock-path in Docker containers widget

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2241,7 +2241,7 @@ The path to the Docker socket. This can also be a [remote socket](https://docs.d
 
 If the socket path starts with `tcp://` or `http://`, it will be treated as a remote socket. Anything else will be treated as a path to a Unix socket.
 
-###### `category`
+##### `category`
 Filter to only the containers which have this category specified via the `glance.category` label. Useful if you want to have multiple containers widgets, each showing a different set of containers.
 
 <details>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2239,6 +2239,8 @@ When set to `true`, automatically converts container names such as `container_na
 ##### `sock-path`
 The path to the Docker socket. This can also be a [remote socket](https://docs.docker.com/engine/daemon/remote-access/) or proxied socket using something like [docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy).
 
+If the socket path starts with `tcp://` or `http://`, it will be treated as a remote socket. Anything else will be treated as a path to a Unix socket.
+
 ###### `category`
 Filter to only the containers which have this category specified via the `glance.category` label. Useful if you want to have multiple containers widgets, each showing a different set of containers.
 


### PR DESCRIPTION
I had to figure this out myself from looking at the source, so thought I'd push a quick doc update for it.