### PR TITLE
fix: clear search bang tag via enter

### DIFF
--- a/internal/glance/static/js/page.js
+++ b/internal/glance/static/js/page.js
@@ -152,6 +152,7 @@ function setupSearchBoxes() {
 
                 lastQuery = query;
                 inputElement.value = "";
+                changeCurrentBang(null);
 
                 return;
             }


### PR DESCRIPTION
#252 added clearing the input on enter, but the tag persisted (regardless of the `target`, but especially noticable when `target: _blank`) found it quite irritating to have a tag with an empty input, only a minor visual fix

calling `changeCurrentBang(null)` after clearing the input resets both