### PR TITLE
Feat: Live widget updates via SSE without full page reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /playground
 /.idea
 /glance*.yml
+/hack/mock-upstream/mock-upstream

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -301,6 +301,7 @@ server:
 | proxied | boolean | no | false |
 | base-url | string | no | |
 | assets-path | string | no |  |
+| live-updates | boolean | no | false |
 
 #### `host`
 The address which the server will listen on. Setting it to `localhost` means that only the machine that the server is running on will be able to access the dashboard. By default it will listen on all interfaces.
@@ -340,6 +341,24 @@ The path to a directory that will be served by the server under the `/assets/` p
 > ```
 > assets-path: /app/assets
 > ```
+
+#### `live-updates`
+When set to `true`, Glance pushes widget updates to the browser via [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) (SSE) so the dashboard refreshes without a full page reload. Disabled by default.
+
+How it works:
+
+- A background ticker checks each widget's cache expiry every 10 seconds. A widget is only fetched from its upstream source when its configured `cache` duration has elapsed — the tick interval does **not** override per-widget cache settings.
+- After an update, the rendered HTML of the widget is compared with the previous render. An event is sent to connected browsers only when the content actually changed.
+- The browser opens a persistent SSE connection to `{base-url}/api/events`. On receiving a `widget-updated` event it fetches the new HTML for that widget from `{base-url}/api/widgets/{id}/content/` and replaces the widget in the DOM.
+- Multiple events for the same widget that arrive within 500 ms are coalesced into a single fetch.
+
+**Reverse proxy considerations:** SSE requires a long-lived HTTP connection. Make sure your proxy does not apply a short read or request timeout to this path. For nginx, the `X-Accel-Buffering: no` header (sent automatically by Glance) disables proxy buffering. For other proxies, you may need to disable buffering explicitly or increase idle connection timeouts.
+
+You can monitor the raw event stream for debugging:
+
+```bash
+curl -N http://localhost:8080/api/events
+```
 
 ##### Examples
 

--- a/hack/TESTING.md
+++ b/hack/TESTING.md
@@ -1,0 +1,132 @@
+# Manual Testing Guide: live-updates
+
+## Prerequisites
+
+Build Glance and the mock upstream:
+
+```bash
+go build ./...
+go build -o hack/mock-upstream/mock-upstream ./hack/mock-upstream/
+```
+
+## Starting the servers
+
+In terminal 1 — start the mock upstream:
+
+```bash
+./hack/mock-upstream/mock-upstream -addr :9090
+```
+
+In terminal 2 — start Glance with the test config:
+
+```bash
+go run -race . --config hack/glance.live-test.yml
+```
+
+Open http://localhost:8080 in a browser.
+
+## Viewing the raw SSE stream
+
+```bash
+curl -N http://localhost:8080/api/events
+```
+
+You should see `: ping` lines every 30 seconds when idle.
+
+## Test scenarios
+
+### 1. Basic update — bump triggers exactly one refresh
+
+1. Open http://localhost:8080 in a browser. Note the counter value (should be 0).
+2. Bump the counter:
+   ```bash
+   curl -X POST http://localhost:9090/bump
+   ```
+3. Within ~20 seconds, the "Counter (cache 10s)" widget should update without a page reload. The "Counter slow (cache 30m)" widget must **not** update.
+4. The raw SSE stream should show exactly one `widget-updated` event for the 10s widget.
+
+### 2. Coalescing — double bump produces one fetch
+
+1. Bump the counter twice in quick succession:
+   ```bash
+   curl -X POST http://localhost:9090/bump && curl -X POST http://localhost:9090/bump
+   ```
+2. Within ~20 seconds, the 10s widget updates once. The mock upstream log should show the `/data` endpoint being hit once for that widget ID (not twice).
+
+### 3. No spurious events — static widget
+
+1. Wait for more than 30 seconds without bumping.
+2. Verify the raw SSE stream shows only ping comments, no `widget-updated` events.
+3. Verify the mock upstream log shows no `/data` requests for the slow (30m) widget.
+
+### 4. Cache respected — slow widget not over-polled
+
+1. Let the server run for 5 minutes.
+2. Check the mock upstream log. The `/data` endpoint should be hit at most once every 30 minutes for the slow widget.
+
+### 5. Two browser tabs simultaneously
+
+1. Open two tabs on http://localhost:8080.
+2. Bump the counter.
+3. Both tabs should update independently within ~20 seconds.
+
+### 6. Flaky service — monitor widget updates
+
+1. The "Flaky Service" monitor widget alternates between OK and error every 10 seconds.
+2. Verify that the monitor widget updates in the browser each time the status changes.
+
+### 7. Mock upstream restart
+
+1. Kill the mock upstream (Ctrl-C in terminal 1).
+2. Wait for a 10-second tick. The monitor widget should show an error state.
+3. Restart the mock upstream. Within ~20 seconds the widget should recover.
+
+### 8. Glance restart with browser tab open
+
+1. With a tab open on http://localhost:8080, restart Glance (Ctrl-C + rerun).
+2. The browser's EventSource should automatically reconnect. You should not need to refresh the tab.
+3. After reconnect, bumping the counter should still trigger widget updates.
+
+### 9. Hot-reload — config file change
+
+1. Touch the config file:
+   ```bash
+   touch hack/glance.live-test.yml
+   ```
+2. The server should reload. Check the terminal for "Config file changed, reloading...".
+3. If pprof is enabled (`import _ "net/http/pprof"`), check for goroutine leaks:
+   ```bash
+   curl http://localhost:8080/debug/pprof/goroutine?debug=1
+   ```
+   The goroutine count should return to baseline after each reload.
+
+### 10. Auth enforcement (if auth is configured)
+
+Add auth to the test config:
+
+```yaml
+auth:
+  secret-key: <base64-key>   # go run . --secret-key
+  users:
+    admin:
+      password: testpass
+```
+
+Then verify:
+
+```bash
+curl -I http://localhost:8080/api/events     # expect 401
+curl -I http://localhost:8080/api/widgets/1/content/  # expect 401
+```
+
+## Behind a reverse proxy
+
+When Glance is behind a reverse proxy (nginx, Caddy, Traefik), SSE connections must remain open for the duration of the session. Common pitfalls:
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| Events stop after 60 s | Proxy read/idle timeout | Increase `proxy_read_timeout` (nginx) or equivalent |
+| No events arrive at all | Proxy buffering enabled | Check that `X-Accel-Buffering: no` is forwarded (nginx strips it by default when not proxying upstream) |
+| EventSource reconnects every few seconds | Proxy closes idle keep-alive connections | Increase proxy keep-alive or idle timeout |
+
+To debug, open **DevTools → Network → EventStream** tab and watch for connection resets.

--- a/hack/glance.live-test.yml
+++ b/hack/glance.live-test.yml
@@ -23,11 +23,9 @@ pages:
               <p>Count: {{ .JSON.Int "count" }}</p>
               <p>Last refreshed: {{ now | formatTime "15:04:05" }}</p>
 
-          - type: custom-api
+          - type: monitor
             title: Flaky Service
             cache: 10s
-            url: http://localhost:9090/flaky
-            skip-json-validation: true
-            template: |
-              <p>Status: {{ .Response.StatusCode }}</p>
-              <p>Last refreshed: {{ now | formatTime "15:04:05" }}</p>
+            sites:
+              - title: Flaky
+                url: http://localhost:9090/flaky

--- a/hack/glance.live-test.yml
+++ b/hack/glance.live-test.yml
@@ -13,6 +13,7 @@ pages:
             url: http://localhost:9090/data
             template: |
               <p>Count: {{ .JSON.Int "count" }}</p>
+              <p>Last refreshed: {{ now | formatTime "15:04:05" }}</p>
 
           - type: custom-api
             title: Counter slow (cache 30m)
@@ -20,6 +21,7 @@ pages:
             url: http://localhost:9090/data
             template: |
               <p>Count: {{ .JSON.Int "count" }}</p>
+              <p>Last refreshed: {{ now | formatTime "15:04:05" }}</p>
 
           - type: monitor
             title: Flaky Service

--- a/hack/glance.live-test.yml
+++ b/hack/glance.live-test.yml
@@ -1,0 +1,29 @@
+server:
+  port: 8080
+  live-updates: true
+
+pages:
+  - name: Live Updates Test
+    columns:
+      - size: full
+        widgets:
+          - type: custom-api
+            title: Counter (cache 10s)
+            cache: 10s
+            url: http://localhost:9090/data
+            template: |
+              <p>Count: {{.JSON.count}}</p>
+
+          - type: custom-api
+            title: Counter slow (cache 30m)
+            cache: 30m
+            url: http://localhost:9090/data
+            template: |
+              <p>Count: {{.JSON.count}}</p>
+
+          - type: monitor
+            title: Flaky Service
+            cache: 10s
+            sites:
+              - title: Flaky
+                url: http://localhost:9090/flaky

--- a/hack/glance.live-test.yml
+++ b/hack/glance.live-test.yml
@@ -23,9 +23,11 @@ pages:
               <p>Count: {{ .JSON.Int "count" }}</p>
               <p>Last refreshed: {{ now | formatTime "15:04:05" }}</p>
 
-          - type: monitor
+          - type: custom-api
             title: Flaky Service
             cache: 10s
-            sites:
-              - title: Flaky
-                url: http://localhost:9090/flaky
+            url: http://localhost:9090/flaky
+            skip-json-validation: true
+            template: |
+              <p>Status: {{ .Response.StatusCode }}</p>
+              <p>Last refreshed: {{ now | formatTime "15:04:05" }}</p>

--- a/hack/glance.live-test.yml
+++ b/hack/glance.live-test.yml
@@ -12,14 +12,14 @@ pages:
             cache: 10s
             url: http://localhost:9090/data
             template: |
-              <p>Count: {{.JSON.count}}</p>
+              <p>Count: {{ .JSON.Int "count" }}</p>
 
           - type: custom-api
             title: Counter slow (cache 30m)
             cache: 30m
             url: http://localhost:9090/data
             template: |
-              <p>Count: {{.JSON.count}}</p>
+              <p>Count: {{ .JSON.Int "count" }}</p>
 
           - type: monitor
             title: Flaky Service

--- a/hack/mock-upstream/main.go
+++ b/hack/mock-upstream/main.go
@@ -1,0 +1,56 @@
+// Mock upstream server for manual live-updates testing.
+// Endpoints:
+//   GET  /data  — returns JSON with a counter value
+//   POST /bump  — increments the counter and returns the new value
+//   GET  /flaky — alternates between 200 and 503 on each request
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"sync/atomic"
+)
+
+var counter atomic.Int64
+var flakyState atomic.Bool
+
+func main() {
+	addr := flag.String("addr", ":9090", "listen address")
+	flag.Parse()
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /data", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		v := counter.Load()
+		log.Printf("GET /data → %d", v)
+		json.NewEncoder(w).Encode(map[string]int64{"count": v})
+	})
+
+	mux.HandleFunc("POST /bump", func(w http.ResponseWriter, _ *http.Request) {
+		v := counter.Add(1)
+		log.Printf("POST /bump → %d", v)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]int64{"count": v})
+	})
+
+	mux.HandleFunc("GET /flaky", func(w http.ResponseWriter, _ *http.Request) {
+		if flakyState.Load() {
+			flakyState.Store(false)
+			log.Printf("GET /flaky → 503")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		flakyState.Store(true)
+		log.Printf("GET /flaky → 200")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	log.Printf("mock upstream listening on %s", *addr)
+	if err := http.ListenAndServe(*addr, mux); err != nil {
+		fmt.Println(err)
+	}
+}

--- a/internal/glance/config.go
+++ b/internal/glance/config.go
@@ -29,11 +29,12 @@ const (
 
 type config struct {
 	Server struct {
-		Host       string `yaml:"host"`
-		Port       uint16 `yaml:"port"`
-		Proxied    bool   `yaml:"proxied"`
-		AssetsPath string `yaml:"assets-path"`
-		BaseURL    string `yaml:"base-url"`
+		Host        string `yaml:"host"`
+		Port        uint16 `yaml:"port"`
+		Proxied     bool   `yaml:"proxied"`
+		AssetsPath  string `yaml:"assets-path"`
+		BaseURL     string `yaml:"base-url"`
+		LiveUpdates bool   `yaml:"live-updates"`
 	} `yaml:"server"`
 
 	Auth struct {

--- a/internal/glance/events.go
+++ b/internal/glance/events.go
@@ -1,0 +1,70 @@
+package glance
+
+import (
+	"sync"
+	"time"
+)
+
+type event struct {
+	Type     string    `json:"type"`
+	WidgetID uint64    `json:"widgetId"`
+	Time     time.Time `json:"time"`
+}
+
+const eventHubChannelBuffer = 8
+
+type eventHub struct {
+	mu      sync.Mutex
+	clients map[chan event]struct{}
+}
+
+func newEventHub() *eventHub {
+	return &eventHub{
+		clients: make(map[chan event]struct{}),
+	}
+}
+
+func (h *eventHub) register() chan event {
+	ch := make(chan event, eventHubChannelBuffer)
+	h.mu.Lock()
+	h.clients[ch] = struct{}{}
+	h.mu.Unlock()
+	return ch
+}
+
+func (h *eventHub) unregister(ch chan event) {
+	h.mu.Lock()
+	if _, exists := h.clients[ch]; exists {
+		delete(h.clients, ch)
+		close(ch)
+	}
+	h.mu.Unlock()
+}
+
+// publish broadcasts e to all registered clients. Slow clients are dropped.
+func (h *eventHub) publish(e event) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for ch := range h.clients {
+		select {
+		case ch <- e:
+		default:
+		}
+	}
+}
+
+// close shuts down all client channels; called when the application is being replaced.
+func (h *eventHub) close() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for ch := range h.clients {
+		close(ch)
+	}
+	h.clients = make(map[chan event]struct{})
+}
+
+func (h *eventHub) clientCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.clients)
+}

--- a/internal/glance/events_test.go
+++ b/internal/glance/events_test.go
@@ -1,0 +1,111 @@
+package glance
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestEventHubBroadcast(t *testing.T) {
+	h := newEventHub()
+	ch1 := h.register()
+	ch2 := h.register()
+
+	e := event{Type: "widget-updated", WidgetID: 42, Time: time.Now()}
+	h.publish(e)
+
+	select {
+	case got := <-ch1:
+		if got.WidgetID != e.WidgetID {
+			t.Errorf("ch1: got widget id %d, want %d", got.WidgetID, e.WidgetID)
+		}
+	case <-time.After(time.Second):
+		t.Error("ch1: timed out waiting for event")
+	}
+
+	select {
+	case got := <-ch2:
+		if got.WidgetID != e.WidgetID {
+			t.Errorf("ch2: got widget id %d, want %d", got.WidgetID, e.WidgetID)
+		}
+	case <-time.After(time.Second):
+		t.Error("ch2: timed out waiting for event")
+	}
+}
+
+func TestEventHubSlowClientDropped(t *testing.T) {
+	h := newEventHub()
+	_ = h.register()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < eventHubChannelBuffer+5; i++ {
+			h.publish(event{Type: "test", WidgetID: uint64(i)})
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Error("publish blocked on slow client")
+	}
+}
+
+func TestEventHubUnregisterClosesChannel(t *testing.T) {
+	h := newEventHub()
+	ch := h.register()
+	h.unregister(ch)
+
+	_, ok := <-ch
+	if ok {
+		t.Error("channel should be closed after unregister")
+	}
+}
+
+func TestEventHubCloseAllClients(t *testing.T) {
+	h := newEventHub()
+	ch1 := h.register()
+	ch2 := h.register()
+
+	h.close()
+
+	_, ok1 := <-ch1
+	_, ok2 := <-ch2
+	if ok1 || ok2 {
+		t.Error("all channels should be closed after hub.close()")
+	}
+	if h.clientCount() != 0 {
+		t.Error("client count should be 0 after hub.close()")
+	}
+}
+
+func TestEventHubConcurrent(t *testing.T) {
+	h := newEventHub()
+	const numClients = 10
+	const numEvents = 50
+
+	var wg sync.WaitGroup
+	for i := 0; i < numClients; i++ {
+		ch := h.register()
+		wg.Add(1)
+		go func(ch chan event) {
+			defer wg.Done()
+			for range ch {
+			}
+		}(ch)
+	}
+
+	var publishWg sync.WaitGroup
+	for i := 0; i < numEvents; i++ {
+		publishWg.Add(1)
+		go func(i int) {
+			defer publishWg.Done()
+			h.publish(event{Type: "test", WidgetID: uint64(i)})
+		}(i)
+	}
+	publishWg.Wait()
+
+	h.close()
+	wg.Wait()
+}

--- a/internal/glance/glance.go
+++ b/internal/glance/glance.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -34,8 +35,12 @@ type application struct {
 
 	parsedManifest []byte
 
-	slugToPage map[string]*page
-	widgetByID map[uint64]widget
+	slugToPage   map[string]*page
+	widgetByID   map[uint64]widget
+	widgetToPage map[uint64]*page
+
+	hub          *eventHub
+	tickerCancel context.CancelFunc
 
 	RequiresAuth           bool
 	authSecretKey          []byte
@@ -46,11 +51,13 @@ type application struct {
 
 func newApplication(c *config) (*application, error) {
 	app := &application{
-		Version:    buildVersion,
-		CreatedAt:  time.Now(),
-		Config:     *c,
-		slugToPage: make(map[string]*page),
-		widgetByID: make(map[uint64]widget),
+		Version:      buildVersion,
+		CreatedAt:    time.Now(),
+		Config:       *c,
+		slugToPage:   make(map[string]*page),
+		widgetByID:   make(map[uint64]widget),
+		widgetToPage: make(map[uint64]*page),
+		hub:          newEventHub(),
 	}
 	config := &app.Config
 
@@ -173,9 +180,8 @@ func newApplication(c *config) (*application, error) {
 		}
 
 		for i := range page.HeadWidgets {
-			widget := page.HeadWidgets[i]
-			app.widgetByID[widget.GetID()] = widget
-			widget.setProviders(providers)
+			registerWidget(app.widgetByID, app.widgetToPage, page.HeadWidgets[i], page)
+			page.HeadWidgets[i].setProviders(providers)
 		}
 
 		for c := range page.Columns {
@@ -186,9 +192,8 @@ func newApplication(c *config) (*application, error) {
 			}
 
 			for w := range column.Widgets {
-				widget := column.Widgets[w]
-				app.widgetByID[widget.GetID()] = widget
-				widget.setProviders(providers)
+				registerWidget(app.widgetByID, app.widgetToPage, column.Widgets[w], page)
+				column.Widgets[w].setProviders(providers)
 			}
 		}
 	}
@@ -228,6 +233,22 @@ func newApplication(c *config) (*application, error) {
 	app.parsedManifest = []byte(manifest)
 
 	return app, nil
+}
+
+// registerWidget adds w (and any container children) to widgetByID and widgetToPage.
+func registerWidget(widgetByID map[uint64]widget, widgetToPage map[uint64]*page, w widget, p *page) {
+	widgetByID[w.GetID()] = w
+	widgetToPage[w.GetID()] = p
+	switch cw := w.(type) {
+	case *groupWidget:
+		for _, child := range cw.Widgets {
+			registerWidget(widgetByID, widgetToPage, child, p)
+		}
+	case *splitColumnWidget:
+		for _, child := range cw.Widgets {
+			registerWidget(widgetByID, widgetToPage, child, p)
+		}
+	}
 }
 
 func (p *page) updateOutdatedWidgets() {
@@ -405,23 +426,77 @@ func (a *application) handleWidgetRequest(w http.ResponseWriter, r *http.Request
 	// TODO: this requires a rework of the widget update logic so that rather
 	// than locking the entire page we lock individual widgets
 	w.WriteHeader(http.StatusNotImplemented)
+}
 
-	// widgetValue := r.PathValue("widget")
+func (a *application) handleSSERequest(w http.ResponseWriter, r *http.Request) {
+	if a.handleUnauthorizedResponse(w, r, showUnauthorizedJSON) {
+		return
+	}
 
-	// widgetID, err := strconv.ParseUint(widgetValue, 10, 64)
-	// if err != nil {
-	// 	a.handleNotFound(w, r)
-	// 	return
-	// }
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
-	// widget, exists := a.widgetByID[widgetID]
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
 
-	// if !exists {
-	// 	a.handleNotFound(w, r)
-	// 	return
-	// }
+	ch := a.hub.register()
+	defer a.hub.unregister(ch)
 
-	// widget.handleRequest(w, r)
+	pingTicker := time.NewTicker(30 * time.Second)
+	defer pingTicker.Stop()
+
+	for {
+		select {
+		case e, ok := <-ch:
+			if !ok {
+				return
+			}
+			data, err := json.Marshal(e)
+			if err != nil {
+				continue
+			}
+			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", e.Type, data)
+			flusher.Flush()
+		case <-pingTicker.C:
+			fmt.Fprintf(w, ": ping\n\n")
+			flusher.Flush()
+		case <-r.Context().Done():
+			return
+		}
+	}
+}
+
+func (a *application) handleWidgetContentRequest(w http.ResponseWriter, r *http.Request) {
+	if a.handleUnauthorizedResponse(w, r, showUnauthorizedJSON) {
+		return
+	}
+
+	widgetID, err := strconv.ParseUint(r.PathValue("id"), 10, 64)
+	if err != nil {
+		a.handleNotFound(w, r)
+		return
+	}
+
+	wgt, exists := a.widgetByID[widgetID]
+	if !exists {
+		a.handleNotFound(w, r)
+		return
+	}
+
+	p := a.widgetToPage[widgetID]
+
+	var html string
+	p.mu.Lock()
+	html = string(wgt.Render())
+	p.mu.Unlock()
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write([]byte(html))
 }
 
 func (a *application) StaticAssetPath(asset string) string {
@@ -443,6 +518,11 @@ func (a *application) server() (func() error, func() error) {
 
 	if !a.Config.Theme.DisablePicker {
 		mux.HandleFunc("POST /api/set-theme/{key}", a.handleThemeChangeRequest)
+	}
+
+	if a.Config.Server.LiveUpdates {
+		mux.HandleFunc("GET /api/events", a.handleSSERequest)
+		mux.HandleFunc("GET /api/widgets/{id}/content/", a.handleWidgetContentRequest)
 	}
 
 	mux.HandleFunc("/api/widgets/{widget}/{path...}", a.handleWidgetRequest)
@@ -508,7 +588,17 @@ func (a *application) server() (func() error, func() error) {
 		return nil
 	}
 
+	if a.Config.Server.LiveUpdates {
+		tickerCtx, cancel := context.WithCancel(context.Background())
+		a.tickerCancel = cancel
+		a.startLiveUpdateTicker(tickerCtx)
+	}
+
 	stop := func() error {
+		a.hub.close()
+		if a.tickerCancel != nil {
+			a.tickerCancel()
+		}
 		return server.Close()
 	}
 

--- a/internal/glance/sse_test.go
+++ b/internal/glance/sse_test.go
@@ -1,0 +1,121 @@
+package glance
+
+import (
+	"bufio"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestApp() *application {
+	return &application{
+		slugToPage:   make(map[string]*page),
+		widgetByID:   make(map[uint64]widget),
+		widgetToPage: make(map[uint64]*page),
+		hub:          newEventHub(),
+	}
+}
+
+func TestSSEEndpointUnauthorized(t *testing.T) {
+	app := newTestApp()
+	app.RequiresAuth = true
+
+	req := httptest.NewRequest("GET", "/api/events", nil)
+	w := httptest.NewRecorder()
+	app.handleSSERequest(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestSSEEndpointContentType(t *testing.T) {
+	app := newTestApp()
+
+	srv := httptest.NewServer(http.HandlerFunc(app.handleSSERequest))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/events")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "text/event-stream") {
+		t.Errorf("expected Content-Type text/event-stream, got %s", ct)
+	}
+}
+
+func TestSSEEndpointReceivesEvent(t *testing.T) {
+	app := newTestApp()
+
+	srv := httptest.NewServer(http.HandlerFunc(app.handleSSERequest))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/events")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Give the handler time to register with the hub
+	time.Sleep(50 * time.Millisecond)
+
+	app.hub.publish(event{Type: "widget-updated", WidgetID: 99})
+
+	eventCh := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "event:") {
+				eventCh <- line
+				return
+			}
+		}
+	}()
+
+	select {
+	case line := <-eventCh:
+		if !strings.Contains(line, "widget-updated") {
+			t.Errorf("unexpected event line: %s", line)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timed out waiting for SSE event")
+	}
+}
+
+func TestSSEEndpointDisconnectCleansUp(t *testing.T) {
+	app := newTestApp()
+
+	srv := httptest.NewServer(http.HandlerFunc(app.handleSSERequest))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/events")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	// Give the handler time to register
+	time.Sleep(50 * time.Millisecond)
+
+	if app.hub.clientCount() != 1 {
+		t.Errorf("expected 1 client, got %d", app.hub.clientCount())
+	}
+
+	resp.Body.Close()
+
+	// Give the handler time to unregister
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if app.hub.clientCount() == 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Errorf("client not unregistered after disconnect; count: %d", app.hub.clientCount())
+}

--- a/internal/glance/static/js/page.js
+++ b/internal/glance/static/js/page.js
@@ -12,8 +12,8 @@ async function fetchPageContent(pageData) {
     return content;
 }
 
-function setupCarousels() {
-    const carouselElements = document.getElementsByClassName("carousel-container");
+function setupCarousels(root = document) {
+    const carouselElements = root.getElementsByClassName("carousel-container");
 
     if (carouselElements.length == 0) {
         return;
@@ -95,8 +95,8 @@ function updateRelativeTimeForElements(elements)
     }
 }
 
-function setupSearchBoxes() {
-    const searchWidgets = document.getElementsByClassName("search");
+function setupSearchBoxes(root = document) {
+    const searchWidgets = root.getElementsByClassName("search");
 
     if (searchWidgets.length == 0) {
         return;
@@ -248,8 +248,8 @@ function setupDynamicRelativeTime() {
     });
 }
 
-function setupGroups() {
-    const groups = document.getElementsByClassName("widget-type-group");
+function setupGroups(root = document) {
+    const groups = root.getElementsByClassName("widget-type-group");
 
     if (groups.length == 0) {
         return;
@@ -308,8 +308,8 @@ function setupGroups() {
     }
 }
 
-function setupLazyImages() {
-    const images = document.querySelectorAll("img[loading=lazy]");
+function setupLazyImages(root = document) {
+    const images = root.querySelectorAll("img[loading=lazy]");
 
     if (images.length == 0) {
         return;
@@ -383,8 +383,8 @@ function attachExpandToggleButton(collapsibleContainer) {
 };
 
 
-function setupCollapsibleLists() {
-    const collapsibleLists = document.querySelectorAll(".list.collapsible-container");
+function setupCollapsibleLists(root = document) {
+    const collapsibleLists = root.querySelectorAll(".list.collapsible-container");
 
     if (collapsibleLists.length == 0) {
         return;
@@ -417,8 +417,8 @@ function setupCollapsibleLists() {
     }
 }
 
-function setupCollapsibleGrids() {
-    const collapsibleGridElements = document.querySelectorAll(".cards-grid.collapsible-container");
+function setupCollapsibleGrids(root = document) {
+    const collapsibleGridElements = root.querySelectorAll(".cards-grid.collapsible-container");
 
     if (collapsibleGridElements.length == 0) {
         return;
@@ -653,8 +653,8 @@ async function setupTodos() {
     }
 }
 
-function setupTruncatedElementTitles() {
-    const elements = document.querySelectorAll(".text-truncate, .single-line-titles .title, .text-truncate-2-lines, .text-truncate-3-lines");
+function setupTruncatedElementTitles(root = document) {
+    const elements = root.querySelectorAll(".text-truncate, .single-line-titles .title, .text-truncate-2-lines, .text-truncate-3-lines");
 
     if (elements.length == 0) {
         return;
@@ -783,4 +783,59 @@ async function setupPage() {
     }
 }
 
+async function setupWidgetBehaviors(root) {
+    setupCarousels(root);
+    setupSearchBoxes(root);
+    setupCollapsibleLists(root);
+    setupCollapsibleGrids(root);
+    setupGroups(root);
+    setupLazyImages(root);
+    setTimeout(() => setupTruncatedElementTitles(root), 50);
+}
+
+function setupLiveUpdates() {
+    if (!pageData.liveUpdates) return;
+
+    const baseURL = pageData.baseURL;
+    const pendingUpdates = new Map();
+
+    const source = new EventSource(`${baseURL}/api/events`);
+
+    source.addEventListener('widget-updated', (e) => {
+        const data = JSON.parse(e.data);
+        const widgetID = data.widgetId;
+
+        if (pendingUpdates.has(widgetID)) {
+            clearTimeout(pendingUpdates.get(widgetID));
+        }
+
+        pendingUpdates.set(widgetID, setTimeout(async () => {
+            pendingUpdates.delete(widgetID);
+
+            const el = document.querySelector(`[data-widget-id="${widgetID}"]`);
+            if (!el) return;
+
+            let response;
+            try {
+                response = await fetch(`${baseURL}/api/widgets/${widgetID}/content/`);
+            } catch (_) {
+                return;
+            }
+            if (!response.ok) return;
+
+            const html = await response.text();
+            const tmp = document.createElement('div');
+            tmp.innerHTML = html;
+            const newEl = tmp.firstElementChild;
+            if (!newEl) return;
+
+            el.replaceWith(newEl);
+            setupWidgetBehaviors(newEl);
+        }, 500));
+    });
+
+    source.onerror = () => {};
+}
+
 setupPage();
+setupLiveUpdates();

--- a/internal/glance/templates/document.html
+++ b/internal/glance/templates/document.html
@@ -8,6 +8,7 @@
         /*{{ if .Page }}*/slug: "{{ .Page.Slug }}",/*{{ end }}*/
         baseURL: "{{ .App.Config.Server.BaseURL }}",
         theme: "{{ .Request.Theme.Key }}",
+        liveUpdates: {{ .App.Config.Server.LiveUpdates }},
     };
     </script>
     <title>{{ block "document-title" . }}{{ end }}</title>

--- a/internal/glance/templates/widget-base.html
+++ b/internal/glance/templates/widget-base.html
@@ -1,4 +1,4 @@
-<div class="widget widget-type-{{ .GetType }}{{ if .CSSClass }} {{ .CSSClass }}{{ end }}">
+<div class="widget widget-type-{{ .GetType }}{{ if .CSSClass }} {{ .CSSClass }}{{ end }}" data-widget-id="{{ .GetID }}">
     {{- if not .HideHeader }}
     <div class="widget-header">
         {{- if ne "" .TitleURL }}

--- a/internal/glance/ticker.go
+++ b/internal/glance/ticker.go
@@ -1,0 +1,94 @@
+package glance
+
+import (
+	"context"
+	"html/template"
+	"sync"
+	"time"
+)
+
+const liveUpdateTickInterval = 10 * time.Second
+
+func (a *application) startLiveUpdateTicker(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(liveUpdateTickInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				a.tickAllPages(ctx)
+			}
+		}
+	}()
+}
+
+func (a *application) tickAllPages(ctx context.Context) {
+	seen := make(map[*page]struct{})
+	for _, p := range a.slugToPage {
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		a.tickPage(ctx, p)
+	}
+}
+
+func (a *application) tickPage(ctx context.Context, p *page) {
+	now := time.Now()
+
+	type candidate struct {
+		wgt      widget
+		prevHTML template.HTML
+	}
+
+	p.mu.Lock()
+
+	var candidates []candidate
+	var toUpdate []widget
+
+	for _, w := range p.HeadWidgets {
+		if w.requiresUpdate(&now) {
+			candidates = append(candidates, candidate{wgt: w, prevHTML: w.Render()})
+			toUpdate = append(toUpdate, w)
+		}
+	}
+	for c := range p.Columns {
+		for _, w := range p.Columns[c].Widgets {
+			if w.requiresUpdate(&now) {
+				candidates = append(candidates, candidate{wgt: w, prevHTML: w.Render()})
+				toUpdate = append(toUpdate, w)
+			}
+		}
+	}
+
+	if len(toUpdate) == 0 {
+		p.mu.Unlock()
+		return
+	}
+
+	var wg sync.WaitGroup
+	for _, w := range toUpdate {
+		wg.Add(1)
+		go func(w widget) {
+			defer wg.Done()
+			w.update(ctx)
+		}(w)
+	}
+	wg.Wait()
+
+	for _, c := range candidates {
+		newHTML := c.wgt.Render()
+		if newHTML != c.prevHTML {
+			a.hub.publish(event{
+				Type:     "widget-updated",
+				WidgetID: c.wgt.GetID(),
+				Time:     now,
+			})
+		}
+	}
+
+	p.mu.Unlock()
+}

--- a/internal/glance/ticker_test.go
+++ b/internal/glance/ticker_test.go
@@ -1,0 +1,117 @@
+package glance
+
+import (
+	"context"
+	"html/template"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeWidget is a controllable widget for ticker tests.
+type fakeWidget struct {
+	widgetBase
+	updateCount  atomic.Int32
+	renderedHTML template.HTML
+	onUpdate     func()
+}
+
+func (fw *fakeWidget) initialize() error { return nil }
+func (fw *fakeWidget) update(_ context.Context) {
+	fw.updateCount.Add(1)
+	if fw.onUpdate != nil {
+		fw.onUpdate()
+	}
+}
+func (fw *fakeWidget) Render() template.HTML {
+	return fw.renderedHTML
+}
+func (fw *fakeWidget) handleRequest(_ http.ResponseWriter, _ *http.Request) {}
+
+func newFakeWidget(nextUpdate time.Time, html template.HTML) *fakeWidget {
+	fw := &fakeWidget{renderedHTML: html}
+	fw.setID(widgetIDCounter.Add(1))
+	fw.cacheType = cacheTypeDuration
+	fw.nextUpdate = nextUpdate
+	return fw
+}
+
+func TestTickerSkipsUpToDateWidgets(t *testing.T) {
+	app := newTestApp()
+	p := &page{}
+
+	fw := newFakeWidget(time.Now().Add(time.Hour), "<div>fresh</div>")
+	p.HeadWidgets = widgets{fw}
+	app.slugToPage["test"] = p
+
+	app.tickPage(context.Background(), p)
+
+	if n := fw.updateCount.Load(); n != 0 {
+		t.Errorf("expected 0 updates for fresh widget, got %d", n)
+	}
+}
+
+func TestTickerUpdatesStaleWidget(t *testing.T) {
+	app := newTestApp()
+	p := &page{}
+
+	fw := newFakeWidget(time.Now().Add(-time.Minute), "<div>stale</div>")
+	p.HeadWidgets = widgets{fw}
+	app.slugToPage["test"] = p
+
+	app.tickPage(context.Background(), p)
+
+	if n := fw.updateCount.Load(); n != 1 {
+		t.Errorf("expected 1 update for stale widget, got %d", n)
+	}
+}
+
+func TestTickerEmitsEventOnChange(t *testing.T) {
+	app := newTestApp()
+	p := &page{}
+
+	fw := newFakeWidget(time.Now().Add(-time.Minute), "<div>old</div>")
+	fw.onUpdate = func() {
+		fw.renderedHTML = "<div>new</div>"
+	}
+	p.HeadWidgets = widgets{fw}
+	app.slugToPage["test"] = p
+
+	ch := app.hub.register()
+
+	app.tickPage(context.Background(), p)
+
+	select {
+	case e := <-ch:
+		if e.Type != "widget-updated" {
+			t.Errorf("expected widget-updated event, got %s", e.Type)
+		}
+		if e.WidgetID != fw.GetID() {
+			t.Errorf("expected widget ID %d, got %d", fw.GetID(), e.WidgetID)
+		}
+	case <-time.After(time.Second):
+		t.Error("expected event not received")
+	}
+}
+
+func TestTickerNoEventWhenContentUnchanged(t *testing.T) {
+	app := newTestApp()
+	p := &page{}
+
+	const unchanged = template.HTML("<div>same</div>")
+	fw := newFakeWidget(time.Now().Add(-time.Minute), unchanged)
+	p.HeadWidgets = widgets{fw}
+	app.slugToPage["test"] = p
+
+	ch := app.hub.register()
+
+	app.tickPage(context.Background(), p)
+
+	select {
+	case e := <-ch:
+		t.Errorf("unexpected event emitted: %+v", e)
+	case <-time.After(100 * time.Millisecond):
+		// correct: no event
+	}
+}

--- a/internal/glance/widget_content_test.go
+++ b/internal/glance/widget_content_test.go
@@ -1,0 +1,106 @@
+package glance
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWidgetContentEndpoint401(t *testing.T) {
+	app := newTestApp()
+	app.RequiresAuth = true
+
+	req := httptest.NewRequest("GET", "/api/widgets/1/content/", nil)
+	w := httptest.NewRecorder()
+	app.handleWidgetContentRequest(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestWidgetContentEndpoint404(t *testing.T) {
+	app := newTestApp()
+
+	req := httptest.NewRequest("GET", "/api/widgets/9999/content/", nil)
+	req.SetPathValue("id", "9999")
+	w := httptest.NewRecorder()
+	app.handleWidgetContentRequest(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestWidgetContentEndpoint200(t *testing.T) {
+	app := newTestApp()
+
+	wgt := &monitorWidget{}
+	wgt.setID(widgetIDCounter.Add(1))
+	wgt.withError(nil)
+	p := &page{}
+
+	app.widgetByID[wgt.GetID()] = wgt
+	app.widgetToPage[wgt.GetID()] = p
+
+	req := httptest.NewRequest("GET", "/api/widgets/{id}/content/", nil)
+	req.SetPathValue("id", fmt.Sprintf("%d", wgt.GetID()))
+	w := httptest.NewRecorder()
+	app.handleWidgetContentRequest(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	if body := w.Body.String(); body == "" {
+		t.Error("expected non-empty HTML body")
+	}
+}
+
+func TestWidgetContentEndpointNestedWidget(t *testing.T) {
+	app := newTestApp()
+
+	child := &monitorWidget{}
+	child.setID(widgetIDCounter.Add(1))
+	child.withError(nil)
+
+	parent := &groupWidget{}
+	parent.setID(widgetIDCounter.Add(1))
+	parent.containerWidgetBase.Widgets = widgets{child}
+
+	p := &page{}
+	registerWidget(app.widgetByID, app.widgetToPage, parent, p)
+
+	req := httptest.NewRequest("GET", "/api/widgets/{id}/content/", nil)
+	req.SetPathValue("id", fmt.Sprintf("%d", child.GetID()))
+	w := httptest.NewRecorder()
+	app.handleWidgetContentRequest(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for nested widget, got %d", w.Code)
+	}
+}
+
+func TestWidgetContentResponseContainsDataWidgetID(t *testing.T) {
+	app := newTestApp()
+
+	wgt := &monitorWidget{}
+	wgt.setID(widgetIDCounter.Add(1))
+	wgt.withError(nil)
+	p := &page{}
+
+	app.widgetByID[wgt.GetID()] = wgt
+	app.widgetToPage[wgt.GetID()] = p
+
+	req := httptest.NewRequest("GET", "/api/widgets/{id}/content/", nil)
+	req.SetPathValue("id", fmt.Sprintf("%d", wgt.GetID()))
+	w := httptest.NewRecorder()
+	app.handleWidgetContentRequest(w, req)
+
+	body := w.Body.String()
+	expected := fmt.Sprintf(`data-widget-id="%d"`, wgt.GetID())
+	if !strings.Contains(body, expected) {
+		t.Errorf("response missing %q; body: %s", expected, body)
+	}
+}

--- a/internal/glance/widget_registration_test.go
+++ b/internal/glance/widget_registration_test.go
@@ -1,0 +1,49 @@
+package glance
+
+import (
+	"testing"
+)
+
+func TestRegisterNestedWidgets(t *testing.T) {
+	child := &monitorWidget{}
+	child.setID(widgetIDCounter.Add(1))
+
+	parent := &groupWidget{}
+	parent.setID(widgetIDCounter.Add(1))
+	parent.containerWidgetBase.Widgets = widgets{child}
+
+	widgetByID := make(map[uint64]widget)
+	widgetToPage := make(map[uint64]*page)
+	p := &page{}
+
+	registerWidget(widgetByID, widgetToPage, parent, p)
+
+	if _, ok := widgetByID[parent.GetID()]; !ok {
+		t.Error("parent widget not in widgetByID")
+	}
+	if _, ok := widgetByID[child.GetID()]; !ok {
+		t.Error("nested child widget not in widgetByID")
+	}
+	if widgetToPage[child.GetID()] != p {
+		t.Error("child widget not associated with correct page")
+	}
+}
+
+func TestRegisterNestedWidgetsSplitColumn(t *testing.T) {
+	child := &monitorWidget{}
+	child.setID(widgetIDCounter.Add(1))
+
+	parent := &splitColumnWidget{}
+	parent.setID(widgetIDCounter.Add(1))
+	parent.containerWidgetBase.Widgets = widgets{child}
+
+	widgetByID := make(map[uint64]widget)
+	widgetToPage := make(map[uint64]*page)
+	p := &page{}
+
+	registerWidget(widgetByID, widgetToPage, parent, p)
+
+	if _, ok := widgetByID[child.GetID()]; !ok {
+		t.Error("nested child widget in split-column not in widgetByID")
+	}
+}


### PR DESCRIPTION
1. A background ticker (per application instance) runs every 10 s and checks each widget's requiresUpdate - so widgets are never fetched more often than the widget's outerHTML in place. Events for the same widget within 500 ms are coalesced into a single fetch.

Enabling
```
server:
  live-updates: true
```

Default is false. With it off, no new goroutines start and the new endpoints are not registered - behaviour is identical to before.

Changes

- Bug fix (prerequisite): widgets nested inside group / split-column containers were not added to the widget-by-ID map, making them unreachable by ID.
Fixed with a recursive registration helper. Covered by a test.
- internal/glance/events.go - in-memory event hub (field on application, not a global; closed on hot-reload)
- internal/glance/ticker.go - background refresh loop with change detection
- internal/glance/glance.go - two new endpoints (/api/events, /api/widgets/{id}/content/); hub/ticker wired into hot-reload cleanup
- internal/glance/templates/widget-base.html - data-widget-id attribute added to every widget wrapper
- internal/glance/static/js/page.js - EventSource client, 500 ms coalescing, scoped DOM re-init after widget swap
- docs/configuration.md - server.live-updates documented including reverse proxy notes

Notes

- Relative timestamps in rendered HTML (e.g. "3m ago") will trigger a spurious change event after each re-render because the text changes every minute regardless of the underlying data. This is a known limitation; comparing pre-render state instead of rendered HTML would require per-widget instrumentation.
- Auth is enforced as the first statement in both new handlers (before any ID parsing or lookup), preventing widget ID enumeration.
- The ticker and hub live on application and are cancelled/closed in server.stop(), so hot-reload does not leak goroutines.