### PR TITLE
Fix Fedd RSS not correctly rendering

### DIFF
--- a/internal/glance/widget-rss.go
+++ b/internal/glance/widget-rss.go
@@ -300,7 +300,7 @@ func (widget *rssWidget) fetchItemsFromFeedTask(request rssFeedRequest) ([]rssFe
 		}
 
 		if item.Title != "" {
-			rssItem.Title = html.UnescapeString(item.Title)
+			rssItem.Title = sanitizeFeedTitle(item.Title)
 		} else {
 			rssItem.Title = shortenFeedDescriptionLen(item.Description, 100)
 		}
@@ -335,17 +335,7 @@ func (widget *rssWidget) fetchItemsFromFeedTask(request rssFeedRequest) ([]rssFe
 			rssItem.ChannelName = feed.Title
 		}
 
-		if item.Image != nil {
-			rssItem.ImageURL = item.Image.URL
-		} else if url := findThumbnailInItemExtensions(item); url != "" {
-			rssItem.ImageURL = url
-		} else if feed.Image != nil {
-			if len(feed.Image.URL) > 0 && feed.Image.URL[0] == '/' {
-				rssItem.ImageURL = strings.TrimRight(feed.Link, "/") + feed.Image.URL
-			} else {
-				rssItem.ImageURL = feed.Image.URL
-			}
-		}
+		rssItem.ImageURL = feedItemImageURL(item, feed, rssItem.Link, request.URL)
 
 		// For some reason gofeed sometimes converts absolute URLs to relative ones, so we need to fix
 		// that here and provide the user with an option to override the prefix in case we get it wrong
@@ -385,6 +375,51 @@ func (widget *rssWidget) fetchItemsFromFeedTask(request rssFeedRequest) ([]rssFe
 	}
 
 	return items, nil
+}
+
+var feedItemImagePattern = regexp.MustCompile(`<img[^>]*?\ssrc=["']([^"']+)["']`)
+
+func feedItemImageURL(item *gofeed.Item, feed *gofeed.Feed, itemLink, requestURL string) string {
+	var image string
+
+	if custom := item.Custom["image"]; custom != "" {
+		image = custom
+	} else if item.Image != nil && item.Image.URL != "" {
+		image = item.Image.URL
+	} else if url := findThumbnailInItemExtensions(item); url != "" {
+		image = url
+	} else if match := feedItemImagePattern.FindStringSubmatch(item.Content); match != nil {
+		image = match[1]
+	} else if feed.Image != nil {
+		image = feed.Image.URL
+	}
+
+	return resolveFeedURL(image, itemLink, feed.Link, requestURL)
+}
+
+func resolveFeedURL(reference string, bases ...string) string {
+	if reference == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(reference)
+	if err != nil {
+		return ""
+	} else if parsed.IsAbs() {
+		if parsed.Scheme != "http" && parsed.Scheme != "https" {
+			return ""
+		}
+
+		return reference
+	}
+
+	for _, b := range bases {
+		if base, err := url.Parse(b); err == nil && base.IsAbs() {
+			return base.ResolveReference(parsed).String()
+		}
+	}
+
+	return ""
 }
 
 func findThumbnailInItemExtensions(item *gofeed.Item) string {
@@ -431,6 +466,35 @@ func sanitizeFeedDescription(description string) string {
 	description = html.UnescapeString(description)
 
 	return description
+}
+
+var htmlTagPattern = regexp.MustCompile(`</?([a-zA-Z][a-zA-Z0-9-]*)[^>]*>`)
+
+func sanitizeFeedTitle(title string) string {
+	if title == "" {
+		return ""
+	}
+
+	title = html.UnescapeString(title)
+
+	closing := make(map[string]bool)
+	for _, match := range htmlTagPattern.FindAllStringSubmatch(title, -1) {
+		if strings.HasPrefix(match[0], "</") {
+			closing[strings.ToLower(match[1])] = true
+		}
+	}
+
+	if len(closing) > 0 {
+		title = htmlTagPattern.ReplaceAllStringFunc(title, func(tag string) string {
+			if closing[strings.ToLower(htmlTagPattern.FindStringSubmatch(tag)[1])] {
+				return ""
+			}
+			return tag
+		})
+	}
+
+	title = sequentialWhitespacePattern.ReplaceAllString(title, " ")
+	return strings.TrimSpace(title)
 }
 
 func shortenFeedDescriptionLen(description string, maxLen int) string {


### PR DESCRIPTION
Fix #1011

This PR includes two fixes to address the issue.

1.
Some RSS titles, such as from Unreal Engine, may contain html tags. 
It seems that the `html.UnescapeString` only decodes html entities, causing them to be rendered as plain text.

I added a `sanitizeFeedTitle` function to removes html tags only when the same tag also appears in closing form (`<p>…</p>`), so wrapping tags are removed while a title that only contain a tag name is left intact.

2. 
To fix image rendering issues, the URL from the `<image>` tag is now checked for each feed.
If no image URL is provided, the first url of the `<img>` tag found in the feed content will be used as a fallback.


I use the following configuration to test this fix
```yaml
- type: rss
  title: Godot Engines
  style: horizontal-cards-2
  feeds:
    - url: https://godotengine.org/rss.xml
      title: Godot Blog
- type: rss
  title: Unreal Engine
  style: horizontal-cards-2
  feeds:
    - url: https://www.unrealengine.com/rss
      title: Unreal Engine Blog
- type: rss
  title: theverge.com
  style: horizontal-cards-2
  feeds:
    - url: https://www.theverge.com/rss/index.xml
      title: theverge.com
- type: rss
  title: arstechnica.com
  style: horizontal-cards-2
  feeds:
    - url: https://feeds.arstechnica.com/arstechnica/index
      title: arstechnica.com
- type: rss
  title: ycombinator
  style: horizontal-cards-2
  feeds:
    - url: https://news.ycombinator.com/rss
      title: ycombinator
- type: rss
  title: NASA
  style: horizontal-cards-2
  feeds:
    - url: https://www.nasa.gov/feed/
      title: NASA
- type: rss
  title: KXCD
  style: horizontal-cards-2
  feeds:
    - url: https://xkcd.com/rss.xml
      title: XKCD
- type: rss
  title: CSS-Tricks
  style: horizontal-cards-2
  feeds:
    - url: https://css-tricks.com/feed
      title: CSS-Tricks

- type: rss
  title: GitHub Blog
  style: horizontal-cards-2
  feeds:
    - url: https://github.blog/feed
      title: GitHub Blog
```

Before this fix:

https://github.com/user-attachments/assets/f45bf0b0-2b1f-4ad5-a693-35cce6bd1f8c

After the fix:

https://github.com/user-attachments/assets/15401dde-f567-41af-9c17-25d763a24954


