### PR TITLE
fix(docker): reflect unhealthy child status

### DIFF
--- a/internal/glance/widget-docker-containers.go
+++ b/internal/glance/widget-docker-containers.go
@@ -137,8 +137,12 @@ func (containers dockerContainerList) sortByStateIconThenTitle() {
 	})
 }
 
-func dockerContainerStateToStateIcon(state string) string {
-	switch state {
+func dockerContainerStateToStateIcon(state, status string) string {
+	if strings.Contains(strings.ToLower(status), "(unhealthy)") {
+		return dockerContainerStateIconWarn
+	}
+
+	switch strings.ToLower(state) {
 	case "running":
 		return dockerContainerStateIconOK
 	case "paused":
@@ -187,7 +191,7 @@ func fetchDockerContainers(
 					dc.Children = append(dc.Children, dockerContainer{
 						Name:      deriveDockerContainerName(child, formatNames),
 						StateText: child.Status,
-						StateIcon: dockerContainerStateToStateIcon(strings.ToLower(child.State)),
+						StateIcon: dockerContainerStateToStateIcon(child.State, child.Status),
 					})
 				}
 			}
@@ -204,7 +208,7 @@ func fetchDockerContainers(
 			}
 		}
 		if !stateIconSupersededByChild {
-			dc.StateIcon = dockerContainerStateToStateIcon(dc.State)
+			dc.StateIcon = dockerContainerStateToStateIcon(dc.State, dc.StateText)
 		}
 
 		dockerContainers = append(dockerContainers, dc)

--- a/internal/glance/widget-docker-containers_test.go
+++ b/internal/glance/widget-docker-containers_test.go
@@ -1,0 +1,39 @@
+package glance
+
+import "testing"
+
+func TestDockerContainerStateToStateIcon(t *testing.T) {
+	tests := []struct {
+		name   string
+		state  string
+		status string
+		want   string
+	}{
+		{
+			name:   "running container",
+			state:  "running",
+			status: "Up 2 hours",
+			want:   dockerContainerStateIconOK,
+		},
+		{
+			name:   "unhealthy running container",
+			state:  "running",
+			status: "Up 2 hours (unhealthy)",
+			want:   dockerContainerStateIconWarn,
+		},
+		{
+			name:  "unhealthy state",
+			state: "unhealthy",
+			want:  dockerContainerStateIconWarn,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := dockerContainerStateToStateIcon(test.state, test.status)
+			if got != test.want {
+				t.Fatalf("dockerContainerStateToStateIcon(%q, %q) = %q, want %q", test.state, test.status, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- detect Docker's `(unhealthy)` marker in the container status text
- use that health result for both standalone containers and grouped child containers
- add regression coverage for running, unhealthy-running, and unhealthy states

## Testing

- `go test ./internal/glance`
- `git diff --check`

Fixes #1043
