### PR TITLE
Exit when the HTTP server fails to start

### DIFF
--- a/internal/glance/main.go
+++ b/internal/glance/main.go
@@ -94,7 +94,7 @@ func serveApp(configPath string) error {
 	// TODO: refactor if this gets any more complex, the current implementation is
 	// difficult to reason about due to all of the callbacks and simultaneous operations,
 	// use a single goroutine and a channel to initiate synchronous changes to the server
-	exitChannel := make(chan struct{})
+	exitChannel := make(chan error, 1)
 	hadValidConfigOnStartup := false
 	var stopServer func() error
 
@@ -108,7 +108,7 @@ func serveApp(configPath string) error {
 			log.Printf("Config has errors: %v", err)
 
 			if !hadValidConfigOnStartup {
-				close(exitChannel)
+				reportExitError(exitChannel, fmt.Errorf("validating config file: %w", err))
 			}
 
 			return
@@ -119,7 +119,7 @@ func serveApp(configPath string) error {
 			log.Printf("Failed to create application: %v", err)
 
 			if !hadValidConfigOnStartup {
-				close(exitChannel)
+				reportExitError(exitChannel, fmt.Errorf("creating application: %w", err))
 			}
 
 			return
@@ -135,14 +135,9 @@ func serveApp(configPath string) error {
 			}
 		}
 
-		go func() {
-			var startServer func() error
-			startServer, stopServer = app.server()
-
-			if err := startServer(); err != nil {
-				log.Printf("Failed to start server: %v", err)
-			}
-		}()
+		var startServer func() error
+		startServer, stopServer = app.server()
+		go startServerAndReport(startServer, exitChannel)
 	}
 
 	onErr := func(err error) {
@@ -176,8 +171,21 @@ func serveApp(configPath string) error {
 		}
 	}
 
-	<-exitChannel
-	return nil
+	return <-exitChannel
+}
+
+func startServerAndReport(startServer func() error, exitChannel chan<- error) {
+	if err := startServer(); err != nil {
+		log.Printf("Failed to start server: %v", err)
+		reportExitError(exitChannel, fmt.Errorf("starting server: %w", err))
+	}
+}
+
+func reportExitError(exitChannel chan<- error, err error) {
+	select {
+	case exitChannel <- err:
+	default:
+	}
 }
 
 func serveUpdateNoticeIfConfigLocationNotMigrated(configPath string) bool {

--- a/internal/glance/main_test.go
+++ b/internal/glance/main_test.go
@@ -1,0 +1,20 @@
+package glance
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestStartServerAndReportReturnsStartupError(t *testing.T) {
+	startErr := errors.New("address already in use")
+	exitChannel := make(chan error, 1)
+
+	startServerAndReport(func() error {
+		return startErr
+	}, exitChannel)
+
+	err := <-exitChannel
+	if !errors.Is(err, startErr) {
+		t.Fatalf("expected startup error to be reported, got %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #950.

Server startup errors from the watched-config path now flow back to serveApp through a buffered error channel. This makes Main return a non-zero exit code for failures such as an occupied or unavailable bind address instead of logging the error and waiting forever. Initial config and application construction failures now use the same error path.

Tests:
- go test ./internal/glance -run TestStartServerAndReportReturnsStartupError -count=1
- go test ./internal/glance -count=1
- go vet ./internal/glance
- git diff --check

AI disclosure: I used Codex to help investigate, implement, and test this change. I reviewed the final diff and test results.