### PR TITLE
Add a same-tab option to the Videos widget

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -873,6 +873,7 @@ Preview:
 | collapse-after | integer | no | 7 |
 | collapse-after-rows | integer | no | 4 |
 | include-shorts | boolean | no | false |
+| same-tab | boolean | no | false |
 | video-url-template | string | no | https://www.youtube.com/watch?v={VIDEO-ID} |
 
 ##### `channels`
@@ -904,6 +905,9 @@ https://www.youtube.com...&list={ID}&...
 
 ##### `limit`
 The maximum number of videos to show.
+
+##### `same-tab`
+When set to `true`, video and channel links open in the same tab.
 
 ##### `collapse-after`
 Specify the number of videos to show when using the `vertical-list` style before the "SHOW MORE" button appears.

--- a/internal/glance/templates/video-card-contents.html
+++ b/internal/glance/templates/video-card-contents.html
@@ -1,11 +1,11 @@
 {{ define "video-card-contents" }}
 <img class="video-thumbnail thumbnail" loading="lazy" src="{{ .ThumbnailUrl }}" alt="">
 <div class="margin-top-10 margin-bottom-widget flex flex-column grow padding-inline-widget">
-    <a class="text-truncate-2-lines margin-bottom-auto color-primary-if-not-visited" href="{{ .Url | safeURL }}" target="_blank" rel="noreferrer">{{ .Title }}</a>
+    <a class="text-truncate-2-lines margin-bottom-auto color-primary-if-not-visited" href="{{ .Url | safeURL }}" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer">{{ .Title }}</a>
     <ul class="list-horizontal-text flex-nowrap margin-top-7">
         <li class="shrink-0" {{ dynamicRelativeTimeAttrs .TimePosted }}></li>
         <li class="min-width-0">
-            <a class="block text-truncate" href="{{ .AuthorUrl }}" target="_blank" rel="noreferrer">{{ .Author }}</a>
+            <a class="block text-truncate" href="{{ .AuthorUrl }}" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer">{{ .Author }}</a>
         </li>
     </ul>
 </div>

--- a/internal/glance/templates/videos-vertical-list.html
+++ b/internal/glance/templates/videos-vertical-list.html
@@ -6,11 +6,11 @@
     <li class="flex thumbnail-parent gap-10 items-center">
         <img class="video-horizontal-list-thumbnail thumbnail" loading="lazy" src="{{ .ThumbnailUrl }}" alt="">
         <div class="min-width-0">
-            <a class="block text-truncate color-primary-if-not-visited" href="{{ .Url | safeURL }}" target="_blank" rel="noreferrer">{{ .Title }}</a>
+            <a class="block text-truncate color-primary-if-not-visited" href="{{ .Url | safeURL }}" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer">{{ .Title }}</a>
             <ul class="list-horizontal-text flex-nowrap">
                 <li class="shrink-0" {{ dynamicRelativeTimeAttrs .TimePosted }}></li>
                 <li class="min-width-0">
-                    <a class="block text-truncate" href="{{ .AuthorUrl }}" target="_blank" rel="noreferrer">{{ .Author }}</a>
+                    <a class="block text-truncate" href="{{ .AuthorUrl }}" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer">{{ .Author }}</a>
                 </li>
             </ul>
         </div>

--- a/internal/glance/widget-videos.go
+++ b/internal/glance/widget-videos.go
@@ -31,6 +31,7 @@ type videosWidget struct {
 	Playlists         []string  `yaml:"playlists"`
 	Limit             int       `yaml:"limit"`
 	IncludeShorts     bool      `yaml:"include-shorts"`
+	SameTab           bool      `yaml:"same-tab"`
 }
 
 func (widget *videosWidget) initialize() error {
@@ -74,6 +75,13 @@ func (widget *videosWidget) update(ctx context.Context) {
 		videos = videos[:widget.Limit]
 	}
 
+	widget.setVideos(videos)
+}
+
+func (widget *videosWidget) setVideos(videos videoList) {
+	for i := range videos {
+		videos[i].SameTab = widget.SameTab
+	}
 	widget.Videos = videos
 }
 
@@ -126,6 +134,7 @@ type video struct {
 	Author       string
 	AuthorUrl    string
 	TimePosted   time.Time
+	SameTab      bool
 }
 
 type videoList []video

--- a/internal/glance/widget-videos_test.go
+++ b/internal/glance/widget-videos_test.go
@@ -1,0 +1,34 @@
+package glance
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVideosWidgetSameTab(t *testing.T) {
+	for _, style := range []string{"horizontal-cards", "grid-cards", "vertical-list"} {
+		t.Run(style, func(t *testing.T) {
+			widget := &videosWidget{
+				Style:   style,
+				SameTab: true,
+			}
+			widget.setVideos(videoList{{
+				Title:     "Video",
+				Url:       "https://example.com/video",
+				Author:    "Channel",
+				AuthorUrl: "https://example.com/channel",
+			}})
+			if err := widget.initialize(); err != nil {
+				t.Fatalf("initialize videos widget: %v", err)
+			}
+
+			rendered := string(widget.Render())
+			if strings.Contains(rendered, `href="https://example.com/video" target="_blank"`) {
+				t.Fatal("expected video link to open in the same tab")
+			}
+			if strings.Contains(rendered, `href="https://example.com/channel" target="_blank"`) {
+				t.Fatal("expected channel link to open in the same tab")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1010.

The Videos widget now supports same-tab: true. The setting applies to video and channel links in all three styles: horizontal-cards, grid-cards, and vertical-list. The default remains unchanged, so links still open in a new tab unless configured otherwise.

Tests:
- go test ./internal/glance -run TestVideosWidgetSameTab -count=1
- go test ./internal/glance -count=1
- go vet ./internal/glance
- git diff --check

AI disclosure: I used Codex to help investigate, implement, and test this change. I reviewed the final diff and test results.