### PR TITLE
Add an option to hide Monitor status details

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1941,9 +1941,13 @@ You can hover over the "ERROR" text to view more information.
 | sites | array | yes | |
 | style | string | no | |
 | show-failing-only | boolean | no | false |
+| hide-details | boolean | no | false |
 
 ##### `show-failing-only`
 Shows only a list of failing sites when set to `true`.
+
+##### `hide-details`
+Hides status text and response times, leaving only each site title and status icon.
 
 ##### `style`
 Used to change the appearance of the widget. Possible values are `compact`.

--- a/internal/glance/templates/monitor-compact.html
+++ b/internal/glance/templates/monitor-compact.html
@@ -22,7 +22,7 @@
 
 {{ define "site" }}
 <a class="size-title-dynamic color-highlight text-truncate block grow" href="{{ .URL | safeURL }}" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer">{{ .Title }}</a>
-{{ if not .Status.TimedOut }}<div>{{ .Status.ResponseTime.Milliseconds | formatNumber }}ms</div>{{ end }}
+{{ if and (not .HideDetails) (not .Status.TimedOut) }}<div>{{ .Status.ResponseTime.Milliseconds | formatNumber }}ms</div>{{ end }}
 {{ if eq .StatusStyle "ok" }}
 <div class="monitor-site-status-icon-compact" title="{{ .Status.Code }}">
     <svg fill="var(--color-positive)" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">

--- a/internal/glance/templates/monitor.html
+++ b/internal/glance/templates/monitor.html
@@ -26,7 +26,7 @@
 {{ end }}
 <div class="grow min-width-0">
     <a class="size-h3 color-highlight text-truncate block" href="{{ .URL | safeURL }}" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer">{{ .Title }}</a>
-    <ul class="list-horizontal-text">
+    {{ if not .HideDetails }}<ul class="list-horizontal-text">
         {{ if not .Status.Error }}
         <li title="{{ .Status.Code }}">{{ .StatusText }}</li>
         <li>{{ .Status.ResponseTime.Milliseconds | formatNumber }}ms</li>
@@ -35,7 +35,7 @@
         {{ else }}
         <li class="color-negative" title="{{ .Status.Error }}">ERROR</li>
         {{ end }}
-    </ul>
+    </ul>{{ end }}
 </div>
 {{ if eq .StatusStyle "ok" }}
 <div class="monitor-site-status-icon">

--- a/internal/glance/widget-monitor.go
+++ b/internal/glance/widget-monitor.go
@@ -27,15 +27,20 @@ type monitorWidget struct {
 		SameTab            bool            `yaml:"same-tab"`
 		StatusText         string          `yaml:"-"`
 		StatusStyle        string          `yaml:"-"`
+		HideDetails        bool            `yaml:"-"`
 		AltStatusCodes     []int           `yaml:"alt-status-codes"`
 	} `yaml:"sites"`
 	Style           string `yaml:"style"`
 	ShowFailingOnly bool   `yaml:"show-failing-only"`
+	HideDetails     bool   `yaml:"hide-details"`
 	HasFailing      bool   `yaml:"-"`
 }
 
 func (widget *monitorWidget) initialize() error {
 	widget.withTitle("Monitor").withCacheDuration(5 * time.Minute)
+	for i := range widget.Sites {
+		widget.Sites[i].HideDetails = widget.HideDetails
+	}
 
 	return nil
 }

--- a/internal/glance/widget-monitor_test.go
+++ b/internal/glance/widget-monitor_test.go
@@ -1,0 +1,44 @@
+package glance
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMonitorWidgetHideDetails(t *testing.T) {
+	for _, style := range []string{"", "compact"} {
+		t.Run(style, func(t *testing.T) {
+			widget := &monitorWidget{
+				Style:       style,
+				HideDetails: true,
+			}
+			widget.Sites = make([]struct {
+				*SiteStatusRequest `yaml:",inline"`
+				Status             *siteStatus     `yaml:"-"`
+				URL                string          `yaml:"-"`
+				ErrorURL           string          `yaml:"error-url"`
+				Title              string          `yaml:"title"`
+				Icon               customIconField `yaml:"icon"`
+				SameTab            bool            `yaml:"same-tab"`
+				StatusText         string          `yaml:"-"`
+				StatusStyle        string          `yaml:"-"`
+				HideDetails        bool            `yaml:"-"`
+				AltStatusCodes     []int           `yaml:"alt-status-codes"`
+			}, 1)
+			widget.Sites[0].Title = "Service"
+			widget.Sites[0].Status = &siteStatus{Code: 200, ResponseTime: 123 * time.Millisecond}
+			widget.Sites[0].StatusText = "OK"
+			widget.Sites[0].StatusStyle = "ok"
+
+			if err := widget.initialize(); err != nil {
+				t.Fatalf("initialize monitor widget: %v", err)
+			}
+
+			rendered := string(widget.Render())
+			if strings.Contains(rendered, "123ms") || strings.Contains(rendered, ">OK<") {
+				t.Fatal("expected status details to be hidden")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #943.

The Monitor widget now supports hide-details: true. It hides status text and response times while preserving each service title and its success/error icon. The setting works in both the standard and compact styles; default rendering is unchanged.

Tests:
- go test ./internal/glance -run TestMonitorWidgetHideDetails -count=1
- go test ./internal/glance -count=1
- go vet ./internal/glance
- git diff --check

AI disclosure: I used Codex to help investigate, implement, and test this change. I reviewed the final diff and test results.