### PR TITLE
Add a same-tab option to Twitch Channels

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2873,6 +2873,7 @@ Preview:
 | channels | array | yes | |
 | collapse-after | integer | no | 5 |
 | sort-by | string | no | viewers |
+| same-tab | boolean | no | false |
 
 ##### `channels`
 A list of channels to display.
@@ -2882,6 +2883,9 @@ How many channels are visible before the "SHOW MORE" button appears. Set to `-1`
 
 ##### `sort-by`
 Can be used to specify the order in which the channels are displayed. Possible values are `viewers` and `live`.
+
+##### `same-tab`
+When set to `true`, channel links open in the same tab. The widget title and category links continue to open in a new tab.
 
 ### Twitch top games
 Display a list of games with the most viewers on Twitch.

--- a/internal/glance/templates/twitch-channels.html
+++ b/internal/glance/templates/twitch-channels.html
@@ -13,7 +13,7 @@
                 </div>
                 {{ end }}
                 {{ if .Exists }}
-                <a href="https://twitch.tv/{{ .Login }}" target="_blank" rel="noreferrer">
+                <a href="https://twitch.tv/{{ .Login }}" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer">
                     <img class="twitch-channel-avatar thumbnail" src="{{ .AvatarUrl }}" alt="" loading="lazy">
                 </a>
                 {{ else }}
@@ -23,7 +23,7 @@
                 {{ end }}
             </div>
             <div class="min-width-0">
-                <a href="https://twitch.tv/{{ .Login }}" class="size-h3{{ if .IsLive }} color-highlight{{ end }} block text-truncate" target="_blank" rel="noreferrer">{{ .Name }}</a>
+                <a href="https://twitch.tv/{{ .Login }}" class="size-h3{{ if .IsLive }} color-highlight{{ end }} block text-truncate" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer">{{ .Name }}</a>
                 {{ if .Exists }}
                     {{ if .IsLive }}
                         {{ if .Category }}

--- a/internal/glance/widget-twitch-channels.go
+++ b/internal/glance/widget-twitch-channels.go
@@ -20,6 +20,7 @@ type twitchChannelsWidget struct {
 	Channels        []twitchChannel `yaml:"-"`
 	CollapseAfter   int             `yaml:"collapse-after"`
 	SortBy          string          `yaml:"sort-by"`
+	SameTab         bool            `yaml:"same-tab"`
 }
 
 func (widget *twitchChannelsWidget) initialize() error {
@@ -52,6 +53,13 @@ func (widget *twitchChannelsWidget) update(ctx context.Context) {
 		channels.sortByLive()
 	}
 
+	widget.setChannels(channels)
+}
+
+func (widget *twitchChannelsWidget) setChannels(channels twitchChannelList) {
+	for i := range channels {
+		channels[i].SameTab = widget.SameTab
+	}
 	widget.Channels = channels
 }
 
@@ -70,6 +78,7 @@ type twitchChannel struct {
 	Category     string
 	CategorySlug string
 	ViewersCount int
+	SameTab      bool
 }
 
 type twitchChannelList []twitchChannel

--- a/internal/glance/widget-twitch-channels_test.go
+++ b/internal/glance/widget-twitch-channels_test.go
@@ -1,0 +1,30 @@
+package glance
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTwitchChannelsWidgetSameTab(t *testing.T) {
+	widget := &twitchChannelsWidget{SameTab: true}
+	widget.setChannels(twitchChannelList{{
+		Login:        "channel",
+		Exists:       true,
+		Name:         "Channel",
+		IsLive:       true,
+		Category:     "Game",
+		CategorySlug: "game",
+	}})
+	if err := widget.initialize(); err != nil {
+		t.Fatalf("initialize Twitch channels widget: %v", err)
+	}
+	widget.withError(nil)
+
+	rendered := string(widget.Render())
+	if strings.Contains(rendered, `href="https://twitch.tv/channel" target="_blank"`) {
+		t.Fatal("expected channel links to open in the same tab")
+	}
+	if !strings.Contains(rendered, `href="https://www.twitch.tv/directory/category/game" target="_blank"`) {
+		t.Fatalf("expected category links to keep opening in a new tab:\n%s", rendered)
+	}
+}


### PR DESCRIPTION
Fixes #975.

The Twitch Channels widget now supports same-tab: true. It applies to channel avatar and name links while leaving the widget title and category links opening in a new tab, as requested. The default behavior remains unchanged.

Tests:
- go test ./internal/glance -run TestTwitchChannelsWidgetSameTab -count=1
- go test ./internal/glance -count=1
- go vet ./internal/glance
- git diff --check

AI disclosure: I used Codex to help investigate, implement, and test this change. I reviewed the final diff and test results.