### PR TITLE
remove GBP from currencyToSymbol map as units are in pence, not pounds

### DIFF
--- a/internal/glance/widget-markets.go
+++ b/internal/glance/widget-markets.go
@@ -214,7 +214,6 @@ var currencyToSymbol = map[string]string{
 	"JPY": "¥",
 	"CAD": "C$",
 	"AUD": "A$",
-	"GBP": "£",
 	"CHF": "Fr",
 	"NZD": "N$",
 	"INR": "₹",


### PR DESCRIPTION
Fixes glanceapp/glance#757