### PR TITLE
feat: add collection of community custom-api widget templates

### DIFF
--- a/custom-widgets/README.md
+++ b/custom-widgets/README.md
@@ -1,0 +1,161 @@
+# Custom Glance Widgets Collection
+
+This directory contains production-ready, dynamic `custom-api` widgets designed for Glance dashboards.
+
+---
+
+## 📦 Included Widgets
+
+| Widget File | Type | Description & Key Features |
+| :--- | :--- | :--- |
+| **`truenas-metrics.yml`** | `custom-api` | System load average, live uptime, active TrueNAS alerts counter, CPU model |
+| **`jellyfin-stats.yml`** | `custom-api` | Live active playback streams (turns green when active), total movies & series count |
+| **`immich-stats.yml`** | `custom-api` | Total photo count, video count, and calculated GB storage usage |
+| **`radarr-stats.yml`** | `custom-api` | Total movies in library, missing movies count, active download queue |
+| **`sonarr-stats.yml`** | `custom-api` | Total series in library, missing episodes count, active download queue |
+| **`cloudflare-tunnel.yml`** | `custom-api` | Real-time connector tunnel health (`healthy`) and public origin IP address |
+| **`tailscale.yml`** | `custom-api` | Tailnet machine IP, relative last-seen timestamp, key expiry countdown |
+| **`netbird.yml`** | `custom-api` | Real-time total connected network peer count |
+
+---
+
+## 🔑 1. Environment Variables Setup
+
+Add the required API keys and IDs to your Glance environment (e.g. `docker-compose.yml` or `.env` file):
+
+```env
+# TrueNAS
+TRUENAS_API_KEY=your_truenas_api_key
+
+# Media Services
+JELLYFIN_API_KEY=your_jellyfin_api_key
+IMMICH_API_KEY=your_immich_api_key
+RADARR_API_KEY=your_radarr_api_key
+SONARR_API_KEY=your_sonarr_api_key
+
+# Cloudflare Tunnel
+CF_ACCOUNT_ID=your_cloudflare_account_id
+CF_TUNNEL_ID=your_cloudflare_tunnel_id
+CF_API_TOKEN=your_cloudflare_api_token
+
+# Tailscale & Netbird
+TAILSCALE_TAILNET=your_tailnet_name
+TAILSCALE_API_KEY=your_tailscale_api_key
+NETBIRD_API_KEY=your_netbird_api_key
+```
+
+---
+
+## 🛠️ 2. How to Use in Your Glance Configuration
+
+### Method A: Direct Embedding (Copy & Paste)
+
+Copy the widget definition directly into the `widgets:` section of any column in your page YAML file (e.g. `pages/home.yml`):
+
+```yaml
+- name: Home
+  columns:
+    - size: full
+      widgets:
+        # Paste the widget snippet here
+        - type: custom-api
+          refresh-interval: 5s
+          title: Jellyfin Stats
+          cache: 2s
+          url: http://<JELLYFIN_IP>:8096/Sessions?api_key=${JELLYFIN_API_KEY}
+          subrequests:
+            counts:
+              url: http://<JELLYFIN_IP>:8096/Items/Counts?api_key=${JELLYFIN_API_KEY}
+          template: |
+            {{- $activeStreams := 0 -}}
+            {{- range .JSON.Array "" -}}
+              {{- if .Exists "NowPlayingItem" -}}
+                {{- $activeStreams = add $activeStreams 1 -}}
+              {{- end -}}
+            {{- end -}}
+            <div class="flex justify-between text-center">
+              <div>
+                <div class="{{ if gt $activeStreams 0 }}color-positive{{ else }}color-highlight{{ end }} size-h3">{{ $activeStreams }}</div>
+                <div class="size-h6{{ if gt $activeStreams 0 }} color-positive{{ end }}">SESSIONS</div>
+              </div>
+              <div>
+                <div class="color-highlight size-h3">{{ (.Subrequest "counts").JSON.Int "MovieCount" }}</div>
+                <div class="size-h6">MOVIES</div>
+              </div>
+              <div>
+                <div class="color-highlight size-h3">{{ (.Subrequest "counts").JSON.Int "SeriesCount" }}</div>
+                <div class="size-h6">SERIES</div>
+              </div>
+            </div>
+```
+
+---
+
+### Method B: Modular File Inclusion (`$include`)
+
+You can keep your page YAML files clean by using Glance's `$include` directive:
+
+```yaml
+- name: Home
+  columns:
+    - size: small
+      widgets:
+        - $include: custom-widgets/truenas-metrics.yml
+        - $include: custom-widgets/cloudflare-tunnel.yml
+        - $include: custom-widgets/tailscale.yml
+        - $include: custom-widgets/netbird.yml
+```
+
+---
+
+## 📐 3. Layout Examples
+
+### Example 1: 2x2 Media Stats Grid
+Arrange 4 media stats widgets side-by-side using `split-column` with `max-columns: 2`:
+
+```yaml
+- type: split-column
+  max-columns: 2
+  widgets:
+    - $include: custom-widgets/jellyfin-stats.yml
+    - $include: custom-widgets/immich-stats.yml
+    - $include: custom-widgets/radarr-stats.yml
+    - $include: custom-widgets/sonarr-stats.yml
+```
+
+### Example 2: 3-Across Network Tunnels Row
+Place Cloudflare Tunnel, Tailscale, and Netbird in a 3-column row:
+
+```yaml
+- type: split-column
+  max-columns: 3
+  widgets:
+    - $include: custom-widgets/cloudflare-tunnel.yml
+    - $include: custom-widgets/tailscale.yml
+    - $include: custom-widgets/netbird.yml
+```
+
+### Example 3: Compact Sidebar Column
+Stack system metrics and network health vertically in a `size: small` sidebar:
+
+```yaml
+- size: small
+  widgets:
+    - type: server-stats
+      title: Host Server
+      servers:
+        - type: local
+          name: TrueNAS
+    - $include: custom-widgets/truenas-metrics.yml
+    - $include: custom-widgets/cloudflare-tunnel.yml
+    - $include: custom-widgets/tailscale.yml
+    - $include: custom-widgets/netbird.yml
+```
+
+---
+
+## ⚙️ Configuration Notes
+
+1. **IP Addresses & Ports:** Replace placeholder IPs (e.g. `<TRUENAS_IP>`, `<JELLYFIN_IP>`) with your actual host IP addresses and ports.
+2. **Tailscale Device Filtering:** In `tailscale.yml`, replace `<TAILSCALE_DEVICE_IP>` with your target device's Tailscale 100.x.y.z IP address.
+3. **Live Refresh Rates:** All widgets use `refresh-interval: 5s` and `cache: 2s` for low-latency live updates without overloading your APIs.

--- a/custom-widgets/cloudflare-tunnel.yml
+++ b/custom-widgets/cloudflare-tunnel.yml
@@ -1,0 +1,20 @@
+# Cloudflare Connector Tunnel Live Status & Origin IP Widget
+- type: custom-api
+  title: Cloudflare Tunnel
+  refresh-interval: 5s
+  cache: 2s
+  url: https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/cfd_tunnel/${CF_TUNNEL_ID}
+  headers:
+    Authorization: "Bearer ${CF_API_TOKEN}"
+    Content-Type: application/json
+  template: |
+    <ul class="list list-gap-10">
+      <li class="flex justify-between align-center">
+        <span class="size-h6 color-paragraph">STATUS</span>
+        <span class="size-h5 color-highlight">{{ .JSON.String "result.status" }}</span>
+      </li>
+      <li class="flex justify-between align-center">
+        <span class="size-h6 color-paragraph">ORIGIN IP</span>
+        <span class="size-h5 color-highlight">{{ $ip := .JSON.String "result.connections.0.origin_ip" }}{{ if eq $ip "" }}N/A{{ else }}{{ $ip }}{{ end }}</span>
+      </li>
+    </ul>

--- a/custom-widgets/immich-stats.yml
+++ b/custom-widgets/immich-stats.yml
@@ -1,0 +1,24 @@
+# Immich Photos, Videos & Storage Usage Widget
+- type: custom-api
+  refresh-interval: 5s
+  title: Immich Stats
+  cache: 2s
+  url: http://<IMMICH_IP>:2283/api/server/statistics
+  headers:
+    x-api-key: ${IMMICH_API_KEY}
+    Accept: application/json
+  template: |
+    <div class="flex justify-between text-center">
+      <div>
+          <div class="color-highlight size-h3">{{ .JSON.Int "photos" | formatNumber }}</div>
+          <div class="size-h6">PHOTOS</div>
+      </div>
+      <div>
+          <div class="color-highlight size-h3">{{ .JSON.Int "videos" | formatNumber }}</div>
+          <div class="size-h6">VIDEOS</div>
+      </div>
+      <div>
+          <div class="color-highlight size-h3">{{ div (.JSON.Int "usage" | toFloat) 1073741824 | toInt | formatNumber }}GB</div>
+          <div class="size-h6">STORAGE</div>
+      </div>
+    </div>

--- a/custom-widgets/jellyfin-stats.yml
+++ b/custom-widgets/jellyfin-stats.yml
@@ -1,0 +1,30 @@
+# Jellyfin Media & Active Stream Sessions Widget (Dynamic Highlight)
+- type: custom-api
+  refresh-interval: 5s
+  title: Jellyfin Stats
+  cache: 2s
+  url: http://<JELLYFIN_IP>:8096/Sessions?api_key=${JELLYFIN_API_KEY}
+  subrequests:
+    counts:
+      url: http://<JELLYFIN_IP>:8096/Items/Counts?api_key=${JELLYFIN_API_KEY}
+  template: |
+    {{- $activeStreams := 0 -}}
+    {{- range .JSON.Array "" -}}
+      {{- if .Exists "NowPlayingItem" -}}
+        {{- $activeStreams = add $activeStreams 1 -}}
+      {{- end -}}
+    {{- end -}}
+    <div class="flex justify-between text-center">
+      <div>
+        <div class="{{ if gt $activeStreams 0 }}color-positive{{ else }}color-highlight{{ end }} size-h3">{{ $activeStreams }}</div>
+        <div class="size-h6{{ if gt $activeStreams 0 }} color-positive{{ end }}">SESSIONS</div>
+      </div>
+      <div>
+        <div class="color-highlight size-h3">{{ (.Subrequest "counts").JSON.Int "MovieCount" }}</div>
+        <div class="size-h6">MOVIES</div>
+      </div>
+      <div>
+        <div class="color-highlight size-h3">{{ (.Subrequest "counts").JSON.Int "SeriesCount" }}</div>
+        <div class="size-h6">SERIES</div>
+      </div>
+    </div>

--- a/custom-widgets/netbird.yml
+++ b/custom-widgets/netbird.yml
@@ -1,0 +1,16 @@
+# Netbird Network Peers Count Widget
+- type: custom-api
+  title: Netbird
+  refresh-interval: 5s
+  cache: 2s
+  url: https://api.netbird.io/api/peers
+  headers:
+    Authorization: "Token ${NETBIRD_API_KEY}"
+    Content-Type: application/json
+  template: |
+    <ul class="list list-gap-10">
+      <li class="flex justify-between align-center">
+        <span class="size-h6 color-paragraph">TOTAL PEERS</span>
+        <span class="size-h5 color-highlight">{{ .JSON.Int "#" }}</span>
+      </li>
+    </ul>

--- a/custom-widgets/radarr-stats.yml
+++ b/custom-widgets/radarr-stats.yml
@@ -1,0 +1,26 @@
+# Radarr Library, Missing & Queue Widget
+- type: custom-api
+  refresh-interval: 5s
+  title: Radarr Stats
+  cache: 2s
+  url: http://<RADARR_IP>:7878/api/v3/movie?apikey=${RADARR_API_KEY}
+  subrequests:
+    missing:
+      url: http://<RADARR_IP>:7878/api/v3/wanted/missing?apikey=${RADARR_API_KEY}
+    queue:
+      url: http://<RADARR_IP>:7878/api/v3/queue?apikey=${RADARR_API_KEY}
+  template: |
+    <div class="flex justify-between text-center">
+      <div>
+        <div class="color-highlight size-h3">{{ len (.JSON.Array "") }}</div>
+        <div class="size-h6">MOVIES</div>
+      </div>
+      <div>
+        <div class="color-highlight size-h3">{{ (.Subrequest "missing").JSON.Int "totalRecords" }}</div>
+        <div class="size-h6">MISSING</div>
+      </div>
+      <div>
+        <div class="color-highlight size-h3">{{ (.Subrequest "queue").JSON.Int "totalRecords" }}</div>
+        <div class="size-h6">QUEUED</div>
+      </div>
+    </div>

--- a/custom-widgets/sonarr-stats.yml
+++ b/custom-widgets/sonarr-stats.yml
@@ -1,0 +1,26 @@
+# Sonarr Series, Missing & Queue Widget
+- type: custom-api
+  refresh-interval: 5s
+  title: Sonarr Stats
+  cache: 2s
+  url: http://<SONARR_IP>:8989/api/v3/series?apikey=${SONARR_API_KEY}
+  subrequests:
+    missing:
+      url: http://<SONARR_IP>:8989/api/v3/wanted/missing?apikey=${SONARR_API_KEY}
+    queue:
+      url: http://<SONARR_IP>:8989/api/v3/queue?apikey=${SONARR_API_KEY}
+  template: |
+    <div class="flex justify-between text-center">
+      <div>
+        <div class="color-highlight size-h3">{{ len (.JSON.Array "") }}</div>
+        <div class="size-h6">SERIES</div>
+      </div>
+      <div>
+        <div class="color-highlight size-h3">{{ (.Subrequest "missing").JSON.Int "totalRecords" }}</div>
+        <div class="size-h6">MISSING</div>
+      </div>
+      <div>
+        <div class="color-highlight size-h3">{{ (.Subrequest "queue").JSON.Int "totalRecords" }}</div>
+        <div class="size-h6">QUEUED</div>
+      </div>
+    </div>

--- a/custom-widgets/tailscale.yml
+++ b/custom-widgets/tailscale.yml
@@ -1,0 +1,50 @@
+# Tailscale Machine Live Address, Last Seen & Expiry Widget
+- type: custom-api
+  title: Tailscale
+  refresh-interval: 5s
+  cache: 2s
+  url: https://api.tailscale.com/api/v2/tailnet/${TAILSCALE_TAILNET}/devices
+  headers:
+    Authorization: "Bearer ${TAILSCALE_API_KEY}"
+    Content-Type: application/json
+  template: |
+    {{ $found := false }}
+    {{ range .JSON.Array "devices" }}
+      {{ $ip0 := .String "addresses.0" }}
+      {{ $ip1 := .String "addresses.1" }}
+      {{ if or (eq $ip0 "<TAILSCALE_DEVICE_IP>") (eq $ip1 "<TAILSCALE_DEVICE_IP>") }}
+        {{ $found = true }}
+        <ul class="list list-gap-10">
+          <li class="flex justify-between align-center">
+            <span class="size-h6 color-paragraph">ADDRESS</span>
+            <span class="size-h5 color-highlight"><TAILSCALE_DEVICE_IP></span>
+          </li>
+          <li class="flex justify-between align-center">
+            <span class="size-h6 color-paragraph">LAST SEEN</span>
+            <span class="size-h5 color-highlight">
+              {{ $lastSeen := .String "lastSeen" }}
+              {{ if ne $lastSeen "" }}
+                <span {{ parseRelativeTime "RFC3339" $lastSeen }}></span>
+              {{ else }}
+                Now
+              {{ end }}
+            </span>
+          </li>
+          <li class="flex justify-between align-center">
+            <span class="size-h6 color-paragraph">EXPIRES</span>
+            <span class="size-h5 color-highlight">
+              {{ $expiry := .String "keyExpiry" }}
+              {{ $disabled := .Bool "keyExpiryDisabled" }}
+              {{ if or $disabled (eq $expiry "") (findMatch "^0001" $expiry) }}
+                Never
+              {{ else }}
+                <span {{ parseRelativeTime "RFC3339" $expiry }}></span>
+              {{ end }}
+            </span>
+          </li>
+        </ul>
+      {{ end }}
+    {{ end }}
+    {{ if not $found }}
+      <div class="size-p color-subdue text-center">Device <TAILSCALE_DEVICE_IP> not found in Tailnet</div>
+    {{ end }}

--- a/custom-widgets/truenas-metrics.yml
+++ b/custom-widgets/truenas-metrics.yml
@@ -1,0 +1,37 @@
+# TrueNAS Scale System Info & Active Alerts Metrics Widget
+- type: custom-api
+  refresh-interval: 10s
+  title: TrueNAS Metrics
+  cache: 5s
+  url: http://<TRUENAS_IP>/api/v2.0/system/info
+  headers:
+    Authorization: Bearer ${TRUENAS_API_KEY}
+  subrequests:
+    alerts:
+      url: http://<TRUENAS_IP>/api/v2.0/alert/list?dismissed=false
+      headers:
+        Authorization: Bearer ${TRUENAS_API_KEY}
+  template: |
+    {{- $activeAlerts := 0 -}}
+    {{- range (.Subrequest "alerts").JSON.Array "" -}}
+      {{- if not (.Bool "dismissed") -}}
+        {{- $activeAlerts = add $activeAlerts 1 -}}
+      {{- end -}}
+    {{- end -}}
+    <div class="flex justify-between text-center">
+      <div>
+        <div class="color-highlight size-h3">{{ printf "%.3f" (.JSON.Float "loadavg.0") }}</div>
+        <div class="size-h6">SYSTEM LOAD</div>
+      </div>
+      <div>
+        <div class="color-highlight size-h3">{{ div (.JSON.Int "uptime_seconds") 86400 }}d{{ div (mod (.JSON.Int "uptime_seconds") 86400) 3600 }}h</div>
+        <div class="size-h6">UPTIME</div>
+      </div>
+      <div>
+        <div class="color-highlight size-h3">{{ $activeAlerts }}</div>
+        <div class="size-h6">ALERTS</div>
+      </div>
+    </div>
+    <div class="text-center margin-top-15">
+      <span class="size-p color-paragraph">{{ .JSON.String "model" }}</span>
+    </div>


### PR DESCRIPTION
## Summary

Adds a collection of **8 production-ready, dynamic `custom-api` widget templates** under `custom-widgets/`, complete with documentation and layout examples.

These widgets leverage `custom-api` with `subrequests` to build rich, real-time dashboard panels — no Go code changes required.

---

## Included Widgets

| Widget | Description |
|:---|:---|
| **`truenas-metrics.yml`** | System load average, live uptime counter, active alerts count, CPU model |
| **`jellyfin-stats.yml`** | Active playback sessions (dynamically turns green), total movies & series |
| **`immich-stats.yml`** | Photo count, video count, calculated GB storage usage |
| **`radarr-stats.yml`** | Movies in library, missing count, active download queue |
| **`sonarr-stats.yml`** | Series in library, missing episodes, active download queue |
| **`cloudflare-tunnel.yml`** | Real-time connector tunnel health status and public origin IP |
| **`tailscale.yml`** | Device address, relative last-seen timestamp, key expiry countdown |
| **`netbird.yml`** | Connected network peer count |

---

## Documentation

`custom-widgets/README.md` includes:
- **Environment variables** setup guide
- **Two integration methods:** direct embedding (copy & paste) and modular `$include` directives
- **Layout examples:** 2×2 media stats grid, 3-across network tunnels row, compact sidebar stack

---

## Notes
- All widgets use generic placeholder IPs (e.g. `<TRUENAS_IP>`, `<JELLYFIN_IP>`) — no hardcoded addresses
- All API keys are referenced via `${ENV_VAR}` syntax
- Uses only existing Glance CSS classes (`color-highlight`, `color-positive`, `size-h3`, etc.)
- Zero modifications to any existing upstream files