### PR TITLE
fix: make mountpoint:info CLI command reachable

### DIFF
--- a/internal/glance/cli.go
+++ b/internal/glance/cli.go
@@ -86,11 +86,7 @@ func parseCliOptions() (*cliOptions, error) {
 	} else if len(args) == 2 {
 		if args[0] == "password:hash" {
 			intent = cliIntentPasswordHash
-		} else {
-			return nil, unknownCommandErr
-		}
-	} else if len(args) == 2 {
-		if args[0] == "mountpoint:info" {
+		} else if args[0] == "mountpoint:info" {
 			intent = cliIntentMountpointInfo
 		} else {
 			return nil, unknownCommandErr


### PR DESCRIPTION

`glance mountpoint:info <path>` is listed in `--help` but always fails with `unknown command`. In `parseCliOptions` there are two identical `else if len(args) == 2` branches — the first (`password:hash`) always wins, so the `mountpoint:info` branch is dead code.

Merged the two-arg commands into one block:

```
$ glance mountpoint:info /
Path: /
FS type: apfs
Used percent: 84.5%
```

`password:hash` behaves the same as before. `go vet` and tests pass.

Fixes #958
