### PR TITLE
Add a `link` page property for external top-navigation entries

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -578,7 +578,7 @@ The name of the page which gets shown in the navigation bar.
 The URL friendly version of the title which is used to access the page. For example if the title of the page is "RSS Feeds" you can make the page accessible via `localhost:8080/feeds` by setting the slug to `feeds`. If not defined, it will automatically be generated from the title.
 
 #### `link`
-Makes this page entry a plain external link in the navigation bar instead of a local page: clicking it navigates the browser straight to the given URL, nothing is rendered by Glance for it, and no `/{slug}` route is registered. Useful for linking out to another Glance instance (or any other page) from the nav bar without embedding it. A page using `link` cannot also define `columns` or `head-widgets`, and cannot be the first page in the list (the first page is always used as the home page). Opens in a new tab by default, same as monitor/docker-containers widget links -- see `same-tab` below. Example:
+Makes this page entry a plain external link in the navigation bar instead of a local page: clicking it navigates the browser straight to the given URL, nothing is rendered by Glance for it, and no `/{slug}` route is registered. Useful for linking out to another Glance instance (or any other page) from the nav bar without embedding it. A page using `link` cannot also define `columns` or `head-widgets`. The home page (`/`) is the first page in the list that *isn't* a `link` page -- link pages can be placed anywhere in the list, including before your real pages, without affecting which page serves as home; at least one non-`link` page must exist. Opens in a new tab by default, same as monitor/docker-containers widget links -- see `same-tab` below. Example:
 
 ```yaml
 pages:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -561,19 +561,39 @@ pages:
 | ---- | ---- | -------- | ------- |
 | name | string | yes | |
 | slug | string | no | |
+| link | string | no | |
+| same-tab | boolean | no | false |
 | width | string | no | |
 | desktop-navigation-width | string | no | |
 | center-vertically | boolean | no | false |
 | hide-desktop-navigation | boolean | no | false |
 | show-mobile-header | boolean | no | false |
 | head-widgets | array | no | |
-| columns | array | yes | |
+| columns | array | yes, unless `link` is set | |
 
 #### `name`
 The name of the page which gets shown in the navigation bar.
 
 #### `slug`
 The URL friendly version of the title which is used to access the page. For example if the title of the page is "RSS Feeds" you can make the page accessible via `localhost:8080/feeds` by setting the slug to `feeds`. If not defined, it will automatically be generated from the title.
+
+#### `link`
+Makes this page entry a plain external link in the navigation bar instead of a local page: clicking it navigates the browser straight to the given URL, nothing is rendered by Glance for it, and no `/{slug}` route is registered. Useful for linking out to another Glance instance (or any other page) from the nav bar without embedding it. A page using `link` cannot also define `columns` or `head-widgets`, and cannot be the first page in the list (the first page is always used as the home page). Opens in a new tab by default, same as monitor/docker-containers widget links -- see `same-tab` below. Example:
+
+```yaml
+pages:
+  - name: Home
+    columns: ...
+
+  - name: Homelab
+    columns: ...
+
+  - name: Grafana
+    link: https://grafana.example.com/
+```
+
+#### `same-tab`
+Only applies to pages using `link`. When `false` (default), the link opens in a new tab, matching the same-tab behavior of the monitor and docker-containers widgets elsewhere in Glance. Set to `true` to navigate in the current tab instead.
 
 #### `width`
 The maximum width of the page on desktop. Possible values are `default`, `slim` and `wide`.

--- a/internal/glance/config.go
+++ b/internal/glance/config.go
@@ -485,6 +485,17 @@ func isConfigStateValid(config *config) error {
 		}
 	}
 
+	hasNonLinkPage := false
+	for i := range config.Pages {
+		if config.Pages[i].Link == "" {
+			hasNonLinkPage = true
+			break
+		}
+	}
+	if !hasNonLinkPage {
+		return fmt.Errorf("at least one page must not use link -- it's needed to serve as the home page")
+	}
+
 	for i := range config.Pages {
 		page := &config.Pages[i]
 
@@ -493,10 +504,6 @@ func isConfigStateValid(config *config) error {
 		}
 
 		if page.Link != "" {
-			if i == 0 {
-				return fmt.Errorf("page 1 is used as the home page and cannot use link")
-			}
-
 			if len(page.Columns) > 0 || len(page.HeadWidgets) > 0 {
 				return fmt.Errorf("page %d: link cannot be combined with columns or head-widgets", i+1)
 			}

--- a/internal/glance/config.go
+++ b/internal/glance/config.go
@@ -77,6 +77,8 @@ type user struct {
 type page struct {
 	Title                  string  `yaml:"name"`
 	Slug                   string  `yaml:"slug"`
+	Link                   string  `yaml:"link"`
+	SameTab                bool    `yaml:"same-tab"`
 	Width                  string  `yaml:"width"`
 	DesktopNavigationWidth string  `yaml:"desktop-navigation-width"`
 	ShowMobileHeader       bool    `yaml:"show-mobile-header"`
@@ -488,6 +490,18 @@ func isConfigStateValid(config *config) error {
 
 		if page.Title == "" {
 			return fmt.Errorf("page %d has no name", i+1)
+		}
+
+		if page.Link != "" {
+			if i == 0 {
+				return fmt.Errorf("page 1 is used as the home page and cannot use link")
+			}
+
+			if len(page.Columns) > 0 || len(page.HeadWidgets) > 0 {
+				return fmt.Errorf("page %d: link cannot be combined with columns or head-widgets", i+1)
+			}
+
+			continue
 		}
 
 		if page.Width != "" && (page.Width != "wide" && page.Width != "slim" && page.Width != "default") {

--- a/internal/glance/glance.go
+++ b/internal/glance/glance.go
@@ -144,7 +144,16 @@ func newApplication(c *config) (*application, error) {
 	// Init pages
 	//
 
-	app.slugToPage[""] = &config.Pages[0]
+	// The home page ("/") is the first page in the list that isn't a link page -- link
+	// pages have no content to serve as the root, so they're skipped over here rather than
+	// forcing whichever page happens to have real content to also be first in the nav order.
+	// isConfigStateValid guarantees at least one such page exists.
+	for i := range config.Pages {
+		if config.Pages[i].Link == "" {
+			app.slugToPage[""] = &config.Pages[i]
+			break
+		}
+	}
 
 	providers := &widgetProviders{
 		assetResolver: app.StaticAssetPath,

--- a/internal/glance/glance.go
+++ b/internal/glance/glance.go
@@ -154,6 +154,12 @@ func newApplication(c *config) (*application, error) {
 		page := &config.Pages[p]
 		page.PrimaryColumnIndex = -1
 
+		if page.Link != "" {
+			// link pages contribute a nav entry only (see templates/page.html) and are
+			// deliberately never added to slugToPage -- there's no local content to route to
+			continue
+		}
+
 		if page.Slug == "" {
 			page.Slug = titleToSlug(page.Title)
 		}

--- a/internal/glance/templates/page.html
+++ b/internal/glance/templates/page.html
@@ -8,7 +8,12 @@
 
 {{ define "navigation-links" }}
 {{ range .App.Config.Pages }}
+{{ if .Link }}
+<a href="{{ .Link | safeURL }}" class="nav-item" {{ if not .SameTab }}target="_blank"{{ end }} rel="noreferrer"><div class="nav-item-text">{{ .Title }}</div></a>
+{{ else }}
 <a href="{{ $.App.Config.Server.BaseURL }}/{{ .Slug }}" class="nav-item{{ if eq .Slug $.Page.Slug }} nav-item-current{{ end }}"{{ if eq .Slug $.Page.Slug }} aria-current="page"{{ end }}><div class="nav-item-text">{{ .Title }}</div></a>
+{{ end }}
+{{ end }}
 {{ end }}
 {{ end }}
 


### PR DESCRIPTION
Closes #1068.

## What this adds

An optional `link` property on a page entry. When set, that page contributes a normal top-nav tab, but its `<a>` points straight at the given URL instead of a local `/{slug}` route — no content is rendered, no route is registered, clicking it is a plain external navigation. Also adds `same-tab` (default `false`, opens in a new tab), matching the existing convention already used by the `monitor` and `docker-containers` widgets elsewhere in the codebase, rather than inventing a new one.

```yaml
pages:
  - name: Home
    columns: ...
  - name: Grafana
    link: https://grafana.example.com/
  - name: Internal Wiki
    link: https://wiki.example.com/
    same-tab: true
```

## Why

I run Glance natively on three machines in a homelab (each needs its own `docker-containers`/`server-stats` widgets, which require a local `docker.sock` and local disk — they can't be proxied). I wanted each instance's nav to link to the others, the same way any other nav tab works, without embedding via `iframe` (which has real downsides: a nested page in a fixed-height frame, double-applied theme CSS, and mixed-content blocking if the parent page is HTTPS and the target isn't). See #1068 for the full writeup.

## Design decisions

- **`link` is a page property, not a `$link:`-style directive parallel to `$include`.** `$include` works by splicing another file's raw YAML text in before parsing even starts (see `configIncludePattern` in `config.go`) — a link page isn't "insert this file's content," it's a distinct, tiny entry in the `pages:` list that never gets a route. A plain struct field fits that better.
- **`same-tab` reuses existing convention** rather than adding a new `target`/`new-tab` property — pointed out during implementation that Glance already has this exact pattern (`monitor.html`, `docker-containers.html`, `monitor-compact.html` all use `{{ if not .SameTab }}target="_blank"{{ end }}`), so this follows it instead of introducing a second way to express the same thing.
- **The home page (`/`) is the first page in the list that *isn't* a `link` page**, not unconditionally `Pages[0]`. Originally I hard-required the first page in the list to be non-`link`, but that forces an instance with only one real page (plus several links to sibling instances, as in my actual 3-machine setup) to always show its own tab first in the nav rather than in its natural position — jumpy when every instance is meant to show an identical nav. Link pages can now be written anywhere, including before the real content; the only remaining requirement is that at least one non-`link` page exists somewhere in the list.
- A page using `link` cannot also define `columns` or `head-widgets` (validated, clear error).

## Testing

No Go tests added (happy to add some if wanted — wasn't sure what style/location you'd prefer, e.g. a table-driven test in a new `config_test.go`). Verified manually against a real running instance before opening this:
- Nav renders the external link correctly, `same-tab` toggles `target="_blank"` on/off
- No route is registered for a `link` page (visiting its would-be slug 404s)
- The home page resolves to the first non-`link` page regardless of array position
- Both validation errors trigger correctly: `link` + `columns`/`head-widgets` combined, and an all-`link` config with no real page at all
- Deployed for real across a 3-machine setup — see the screenshots-free but fully verified writeup in #1068

## Docs

`docs/configuration.md` updated with both new properties and an example.