### PR TITLE
Fix pkg/sysinfo mountpoint auto-detection returning nothing in plain containers

### DIFF
--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -260,9 +260,22 @@ func Collect(req *SystemInfoRequest) (*SystemInfo, []error) {
 	}
 
 	if !req.HideMountpointsByDefault {
-		filesystems, err := disk.Partitions(false)
+		// disk.Partitions(false) asks gopsutil for "physical" filesystems only, but its
+		// notion of physical excludes "overlay" -- the storage driver Docker uses for a
+		// container's own root filesystem by default. In a plain container with no extra
+		// host mounts, that leaves auto-detection with nothing to report except whatever
+		// tiny /etc/* config-file bind mounts Docker injects (which get hidden by callers
+		// like glanceapp/agent's default container mountpoint list anyway), so the net
+		// result is an empty mountpoints list even though there's a real, meaningful disk
+		// behind the overlay root worth reporting on. disk.Partitions(true) plus an
+		// allowlist of genuinely disk-backed filesystem types (keeping "overlay") reports
+		// that root correctly while still excluding proc/sysfs/tmpfs/etc noise.
+		filesystems, err := disk.Partitions(true)
 		if err == nil {
 			for _, fs := range filesystems {
+				if !isPhysicalFilesystemType(fs.Fstype) {
+					continue
+				}
 				addMountpointInfo(fs.Mountpoint, req.Mountpoints[fs.Mountpoint])
 			}
 		} else {
@@ -279,6 +292,38 @@ func Collect(req *SystemInfoRequest) (*SystemInfo, []error) {
 	})
 
 	return info, errs
+}
+
+// physicalFilesystemTypes lists the filesystem types treated as real, disk-backed storage
+// worth reporting usage for by default -- an allowlist rather than a denylist of virtual
+// types (proc, sysfs, tmpfs, devpts, mqueue, cgroup, cgroup2, ...) since the set of virtual
+// filesystem types grows over time while real disk filesystem types are comparatively stable.
+// "overlay" is deliberately included: it's technically a union filesystem rather than a disk
+// filesystem, but it's what Docker uses for a container's own root by default, and reports
+// accurate usage of the underlying host disk -- excluding it is what left auto-detection
+// finding nothing to report in a plain container with no extra host mounts.
+var physicalFilesystemTypes = map[string]bool{
+	"overlay":  true,
+	"ext2":     true,
+	"ext3":     true,
+	"ext4":     true,
+	"xfs":      true,
+	"btrfs":    true,
+	"zfs":      true,
+	"ntfs":     true,
+	"vfat":     true,
+	"exfat":    true,
+	"hfs":      true,
+	"hfsplus":  true,
+	"apfs":     true,
+	"f2fs":     true,
+	"jfs":      true,
+	"reiserfs": true,
+	"udf":      true,
+}
+
+func isPhysicalFilesystemType(fstype string) bool {
+	return physicalFilesystemTypes[fstype]
 }
 
 func inferCPUTempSensor(sensors []sensors.TemperatureStat) *sensors.TemperatureStat {


### PR DESCRIPTION
Addresses the root cause raised in #1068 — thanks for pointing at `pkg/sysinfo` specifically, that's exactly where it turned out to live.

## The bug

`disk.Partitions(false)` asks gopsutil for "physical" filesystems only — but its notion of physical excludes `overlay`, the storage driver Docker uses for a container's own root filesystem by default. In a plain container with no extra host bind mounts, that leaves auto-detection with nothing to report except a handful of tiny `/etc/hosts`/`/etc/hostname`/`/etc/resolv.conf` config-file bind mounts Docker injects into every container (which callers like `glanceapp/agent`'s default mountpoint list already hide anyway). Net result: an empty `mountpoints` list — not because anything errors, just because nothing survives gopsutil's "physical" filter.

## How I confirmed this, not just guessed it

Companion PR [glanceapp/agent#6](https://github.com/glanceapp/agent/pull/6) fixes a real bug where `LOG_LEVEL=debug` never actually produced output (nothing in that codebase ever configured `log/slog`'s handler to emit Debug-level records) — needed that fixed first to actually *see* what `Collect` was doing instead of guessing from silence.

With that working, I wrote a small standalone probe comparing `disk.Partitions(false)` vs `disk.Partitions(true)` inside a real container:

```
=== disk.Partitions(false) — physical only ===
  device=/dev/mapper/... mountpoint=/etc/resolv.conf fstype=ext4 opts=[rw relatime bind]
  device=/dev/mapper/... mountpoint=/etc/hostname    fstype=ext4 opts=[rw relatime bind]
  device=/dev/mapper/... mountpoint=/etc/hosts       fstype=ext4 opts=[rw relatime bind]

=== disk.Partitions(true) — all ===
  device=overlay mountpoint=/ fstype=overlay opts=[rw relatime]
  device=proc    mountpoint=/proc ...
  (+ the same three /etc/* bind mounts, + sysfs/tmpfs/devpts/cgroup/etc.)
```

The overlay root — the thing you'd actually want disk usage for — simply never appears under `(false)` at all.

## The fix

Switch to `disk.Partitions(true)` (get everything) filtered through a `physicalFilesystemTypes` allowlist that includes `overlay` alongside the usual real disk filesystem types (ext4, xfs, btrfs, ntfs, ...). Chose an allowlist over excluding known virtual types, since virtual filesystem types accumulate over time (new pseudo-fs types get added to kernels) while real disk filesystem types are comparatively stable and easy to enumerate.

## Testing

- `go build ./...` and `go vet ./...` clean across the whole repo (nothing else calls `disk.Partitions` or depends on the old physical-only behavior as far as I could find).
- End-to-end against `glanceapp/agent` (via a local `go.mod replace`, no `agent.yml`, no `MOUNTPOINTS` env — the true zero-config default path): mountpoints now correctly reports `/` with real total/used/percent matching the host's actual disk, where it previously reported nothing.
- No test suite exists for this package currently; happy to add table-driven tests for `isPhysicalFilesystemType` if wanted, wasn't sure of your preferred test file layout for `pkg/`.