### PR TITLE
Make glance.hide case insensitive

### DIFF
--- a/internal/glance/utils.go
+++ b/internal/glance/utils.go
@@ -167,6 +167,11 @@ func executeTemplateToString(t *template.Template, data any) (string, error) {
 	return b.String(), nil
 }
 
+func stringToBoolCaseInsensitive(s string) bool {
+	v := strings.ToLower(strings.TrimSpace(s))
+	return v == "true" || v == "yes"
+}
+
 func stringToBool(s string) bool {
 	return s == "true" || s == "yes"
 }

--- a/internal/glance/widget-docker-containers.go
+++ b/internal/glance/widget-docker-containers.go
@@ -276,7 +276,7 @@ func groupDockerContainerChildren(
 
 func isDockerContainerHidden(container *dockerContainerJsonResponse, hideByDefault bool) bool {
 	if v := container.Labels.getOrDefault(dockerContainerLabelHide, ""); v != "" {
-		return stringToBool(v)
+		return stringToBoolCaseInsensitive(v)
 	}
 
 	return hideByDefault


### PR DESCRIPTION
(& trim whitespace)

The `glance.hide` label is currently case-sensitive. Podman-compose serializes `glance.hide: true` to `glance.hide = "True"` for some reason (possibly a Python thing). While this should probably be considered bad behavior by podman-compose, case-insensitivity on glance's side also makes sense.

Tested with the docker build.